### PR TITLE
pldmtool: add support for rawMctp

### DIFF
--- a/pldmtool/pldm_cmd_helper.hpp
+++ b/pldmtool/pldm_cmd_helper.hpp
@@ -8,6 +8,10 @@
 #include <libpldm/bios.h>
 #include <libpldm/fru.h>
 #include <libpldm/platform.h>
+#include <linux/mctp.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -72,16 +76,18 @@ void fillCompletionCode(uint8_t completionCode, ordered_json& data,
 
 /** @brief MCTP socket read/receive
  *
+ *  @param[in]  eid - mctp endpoint id
+ *  @mctpPreAllocTag - bool to indicate request for preallocated tag
  *  @param[in]  requestMsg - Request message to compare against loopback
  *              message received from mctp socket
  *  @param[out] responseMsg - Response buffer received from mctp socket
- *  @param[in]  pldmVerbose - verbosity flag - true/false
  *
  *  @return -   0 on success.
  *             -1 or -errno on failure.
  */
-int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
-                     std::vector<uint8_t>& responseMsg, bool pldmVerbose);
+int mctpSockSendRecv(const uint8_t eid, const bool mctpPreAllocTag,
+                     const std::vector<uint8_t>& requestMsg,
+                     void** responseMessage, size_t* responseMessageSize);
 
 class CommandInterface
 {
@@ -150,6 +156,7 @@ class CommandInterface
     uint8_t instanceId;
     pldm::InstanceIdDb instanceIdDb;
     uint8_t numRetries = 0;
+    bool mctpPreAllocTag = false;
 };
 
 } // namespace helper


### PR DESCRIPTION
Added support to send raw MCTP commands of any MCTP type to any any MCTP endpoint.

Following output shows a sample topology of MCTP on the BMC. In this setup, using the pldmtool mctpRaw option, MCTP base command Get Message Type Support (0x05) is sent to the endpoint 13 which is on the mctpi2c81 interface. The endpoint responded with MCTP types 1, 2, 3, and 5.

    root@bmc:~# busctl tree au.com.codeconstruct.MCTP1
    `- /au
      `- /au/com
        `- /au/com/codeconstruct
          `- /au/com/codeconstruct/mctp1
            |- /au/com/codeconstruct/mctp1/interfaces
            | |- /au/com/codeconstruct/mctp1/interfaces/lo
            | |- /au/com/codeconstruct/mctp1/interfaces/mctpi2c180
            | |- /au/com/codeconstruct/mctp1/interfaces/mctpi2c181
            | |- /au/com/codeconstruct/mctp1/interfaces/mctpi2c182
            | |- /au/com/codeconstruct/mctp1/interfaces/mctpi2c8
            | |- /au/com/codeconstruct/mctp1/interfaces/mctpi3c4
            | `- /au/com/codeconstruct/mctp1/interfaces/mctppcie0
            `- /au/com/codeconstruct/mctp1/networks
              `- /au/com/codeconstruct/mctp1/networks/1
                `- /au/com/codeconstruct/mctp1/networks/1/endpoints
                  |- /au/com/codeconstruct/mctp1/networks/1/endpoints/10
                  |- /au/com/codeconstruct/mctp1/networks/1/endpoints/11
                  |- /au/com/codeconstruct/mctp1/networks/1/endpoints/12
                  |- /au/com/codeconstruct/mctp1/networks/1/endpoints/13
                  |- /au/com/codeconstruct/mctp1/networks/1/endpoints/8
                  `- /au/com/codeconstruct/mctp1/networks/1/endpoints/9
    root@bmc:~#

    root@bmc:~# mctp route
    eid min 13 max 13 net 1 dev mctpi2c181 mtu 68
    eid min 12 max 12 net 1 dev mctpi2c182 mtu 0
    eid min 11 max 11 net 1 dev mctpi2c181 mtu 0
    eid min 10 max 10 net 1 dev mctpi2c180 mtu 0
    eid min 9 max 9 net 1 dev mctpi3c4 mtu 0
    eid min 8 max 8 net 1 dev mctppcie0 mtu 0
    root@bmc:~#

    root@bmc:~# pldmtool mctpRaw -m 13 --data 0x00 0x80 0x05
    pldmtool: Tx: 00 80 05
    pldmtool: Rx: 00 05 00 04 01 02 03 05
    root@bmc:~#

Upstream-Status: Inappropriate [Needs refactoring the existing transport
                 interface to support MCTP Transport class. Existing code
                 supports PldmTransport only.]

teted: verified on Congo