### PR TITLE
pldmtool: add network id option for mctpRaw

### DIFF
--- a/pldmtool/pldm_cmd_helper.hpp
+++ b/pldmtool/pldm_cmd_helper.hpp
@@ -76,6 +76,7 @@ void fillCompletionCode(uint8_t completionCode, ordered_json& data,
 
 /** @brief MCTP socket read/receive
  *
+ *  @param[in]  mctpNetworkId - mctp network id
  *  @param[in]  eid - mctp endpoint id
  *  @mctpPreAllocTag - bool to indicate request for preallocated tag
  *  @param[in]  requestMsg - Request message to compare against loopback
@@ -85,7 +86,8 @@ void fillCompletionCode(uint8_t completionCode, ordered_json& data,
  *  @return -   0 on success.
  *             -1 or -errno on failure.
  */
-int mctpSockSendRecv(const uint8_t eid, const bool mctpPreAllocTag,
+int mctpSockSendRecv(const uint8_t mctpNetworkId, const uint8_t eid,
+                     const bool mctpPreAllocTag,
                      const std::vector<uint8_t>& requestMsg,
                      void** responseMessage, size_t* responseMessageSize);
 
@@ -157,6 +159,7 @@ class CommandInterface
     pldm::InstanceIdDb instanceIdDb;
     uint8_t numRetries = 0;
     bool mctpPreAllocTag = false;
+    uint8_t mctpNetworkId = 1;
 };
 
 } // namespace helper

--- a/pldmtool/pldmtool.cpp
+++ b/pldmtool/pldmtool.cpp
@@ -85,6 +85,8 @@ class MctpRawOp : public CommandInterface
     explicit MctpRawOp(const char* type, const char* name, CLI::App* app) :
         CommandInterface(type, name, app)
     {
+        app->add_option("-e,--network-id", mctpNetworkId, "MCTP NetworkId")
+            ->required();
         app->add_option("-d,--data", rawData, "raw MCTP data")
             ->required()
             ->expected(-3);


### PR DESCRIPTION
Add an option to take the nework id as an input parameter to the mctpRaw option.
Also fixes a crash in the pldmtool because of using uninitialized sockaddr length
parameter passed to the recvfrom() call.

following is the usage:

root@ibmc:~# pldmtool mctpRaw --help
send an MCTP raw request and print response
Usage: pldmtool mctpRaw [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  -m,--mctp_eid UINT          MCTP endpoint ID
  -v,--verbose
  -n,--retry-count UINT       Number of retry when PLDM request message is failed
  -e,--network-id UINT REQUIRED
                              MCTP NetworkId
  -d,--data UINT ... REQUIRED raw MCTP data
  -p,--prealloc-tag           use pre-allocated MCTP tag for this request
root@bmc:~#

root@bmc:# pldmtool mctpRaw -m 9 -e 3 --data 0x00 0x80 0x05
pldmtool: Tx: 00 80 05
pldmtool: Rx: 00 05 00 04 01 02 03 05
root@bmc:#

tested: verified on Congo