### PR TITLE
Fix for CI Failures.

### DIFF
--- a/fw-update/device_updater.cpp
+++ b/fw-update/device_updater.cpp
@@ -57,7 +57,9 @@ void DeviceUpdater::startFwUpdateFlow()
 
     rc = updateManager->handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_REQUEST_UPDATE, std::move(request),
-        std::bind_front(&DeviceUpdater::requestUpdate, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->requestUpdate(eid, response, respMsgLen);
+        });
     if (rc)
     {
         // Handle error scenario
@@ -186,7 +188,9 @@ void DeviceUpdater::sendPassCompTableRequest(size_t offset)
     rc = updateManager->handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_PASS_COMPONENT_TABLE,
         std::move(request),
-        std::bind_front(&DeviceUpdater::passCompTable, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->passCompTable(eid, response, respMsgLen);
+        });
     if (rc)
     {
         // Handle error scenario
@@ -317,7 +321,9 @@ void DeviceUpdater::sendUpdateComponentRequest(size_t offset)
 
     rc = updateManager->handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_UPDATE_COMPONENT, std::move(request),
-        std::bind_front(&DeviceUpdater::updateComponent, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->updateComponent(eid, response, respMsgLen);
+        });
     if (rc)
     {
         // Handle error scenario
@@ -669,7 +675,9 @@ void DeviceUpdater::sendActivateFirmwareRequest()
 
     rc = updateManager->handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_ACTIVATE_FIRMWARE, std::move(request),
-        std::bind_front(&DeviceUpdater::activateFirmware, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->activateFirmware(eid, response, respMsgLen);
+        });
     if (rc)
     {
         error(

--- a/fw-update/inventory_manager.cpp
+++ b/fw-update/inventory_manager.cpp
@@ -53,7 +53,9 @@ void InventoryManager::sendQueryDeviceIdentifiersRequest(mctp_eid_t eid)
     rc = handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_QUERY_DEVICE_IDENTIFIERS,
         std::move(requestMsg),
-        std::bind_front(&InventoryManager::queryDeviceIdentifiers, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->queryDeviceIdentifiers(eid, response, respMsgLen);
+        });
     if (rc)
     {
         error(
@@ -184,7 +186,9 @@ void InventoryManager::sendQueryDownstreamDevicesRequest(mctp_eid_t eid)
     rc = handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_QUERY_DOWNSTREAM_DEVICES,
         std::move(requestMsg),
-        std::bind_front(&InventoryManager::queryDownstreamDevices, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->queryDownstreamDevices(eid, response, respMsgLen);
+        });
     if (rc)
     {
         error(
@@ -296,7 +300,9 @@ void InventoryManager::sendQueryDownstreamIdentifiersRequest(
     rc = handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_QUERY_DOWNSTREAM_IDENTIFIERS,
         std::move(requestMsg),
-        std::bind_front(&InventoryManager::queryDownstreamIdentifiers, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->queryDownstreamIdentifiers(eid, response, respMsgLen);
+        });
     if (rc)
     {
         error(
@@ -467,8 +473,9 @@ void InventoryManager::sendGetDownstreamFirmwareParametersRequest(
     rc = handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_QUERY_DOWNSTREAM_FIRMWARE_PARAMETERS,
         std::move(requestMsg),
-        std::bind_front(&InventoryManager::getDownstreamFirmwareParameters,
-                        this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->getDownstreamFirmwareParameters(eid, response, respMsgLen);
+        });
     if (rc)
     {
         error(
@@ -557,7 +564,9 @@ void InventoryManager::sendGetFirmwareParametersRequest(mctp_eid_t eid)
     rc = handler.registerRequest(
         eid, instanceId, PLDM_FWUP, PLDM_GET_FIRMWARE_PARAMETERS,
         std::move(requestMsg),
-        std::bind_front(&InventoryManager::getFirmwareParameters, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->getFirmwareParameters(eid, response, respMsgLen);
+        });
     if (rc)
     {
         error(

--- a/fw-update/update_manager.hpp
+++ b/fw-update/update_manager.hpp
@@ -49,7 +49,10 @@ class UpdateManager
         event(event), handler(handler), instanceIdDb(instanceIdDb),
         descriptorMap(descriptorMap), componentInfoMap(componentInfoMap),
         watch(event.get(),
-              std::bind_front(&UpdateManager::processPackage, this)),
+              [this](std::string& packageFilePath) {
+                  return this->processPackage(
+                      std::filesystem::path(packageFilePath));
+              }),
         totalNumComponentUpdates(0), compUpdateCompletedCount(0)
     {}
 

--- a/host-bmc/host_pdr_handler.cpp
+++ b/host-bmc/host_pdr_handler.cpp
@@ -205,7 +205,9 @@ void HostPDRHandler::getHostPDR(uint32_t nextRecordHandle)
     rc = handler->registerRequest(
         mctp_eid, instanceId, PLDM_PLATFORM, PLDM_GET_PDR,
         std::move(requestMsg),
-        std::bind_front(&HostPDRHandler::processHostPDRs, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->processHostPDRs(eid, response, respMsgLen);
+        });
     if (rc)
     {
         error(

--- a/libpldmresponder/base.cpp
+++ b/libpldmresponder/base.cpp
@@ -190,7 +190,9 @@ Response Handler::getTID(const pldm_msg* request, size_t /*payloadLength*/)
     if (oemPlatformHandler)
     {
         survEvent = std::make_unique<sdeventplus::source::Defer>(
-            event, std::bind_front(&Handler::_processSetEventReceiver, this));
+            event, [this](sdeventplus::source::EventBase& source) {
+                this->_processSetEventReceiver(source);
+            });
     }
 
     return response;

--- a/platform-mc/sensor_manager.cpp
+++ b/platform-mc/sensor_manager.cpp
@@ -39,8 +39,7 @@ void SensorManager::startPolling(pldm_tid_t tid)
     updateAvailableState(tid, true);
 
     sensorPollTimers[tid] = std::make_unique<sdbusplus::Timer>(
-        event.get(),
-        std::bind_front(&SensorManager::doSensorPolling, this, tid));
+        event.get(), [this, tid] { this->doSensorPolling(tid); });
 
     startSensorPollTimer(tid);
 }

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -436,7 +436,10 @@ int main(int argc, char** argv)
 #endif
     stdplus::signal::block(SIGUSR1);
     sdeventplus::source::Signal sigUsr1(
-        event, SIGUSR1, std::bind_front(&interruptFlightRecorderCallBack));
+        event, SIGUSR1,
+        [](Signal& signal, const struct signalfd_siginfo* info) {
+            interruptFlightRecorderCallBack(signal, info);
+        });
     int returnCode = event.loop();
     if (returnCode)
     {

--- a/pldmtool/pldm_cmd_helper.cpp
+++ b/pldmtool/pldm_cmd_helper.cpp
@@ -9,13 +9,13 @@
 #include <libpldm/transport/mctp-demux.h>
 #include <linux/mctp.h>
 #include <poll.h>
-#include <string.h>
 #include <sys/ioctl.h>
 #include <systemd/sd-bus.h>
 
 #include <sdbusplus/server.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
 
+#include <cstring>
 #include <exception>
 
 using namespace pldm::utils;

--- a/pldmtool/pldm_cmd_helper.hpp
+++ b/pldmtool/pldm_cmd_helper.hpp
@@ -76,6 +76,7 @@ void fillCompletionCode(uint8_t completionCode, ordered_json& data,
 
 /** @brief MCTP socket read/receive
  *
+ *  @param[in]  mctpNetworkId - mctp network id
  *  @param[in]  eid - mctp endpoint id
  *  @mctpPreAllocTag - bool to indicate request for preallocated tag
  *  @param[in]  requestMsg - Request message to compare against loopback
@@ -85,7 +86,8 @@ void fillCompletionCode(uint8_t completionCode, ordered_json& data,
  *  @return -   0 on success.
  *             -1 or -errno on failure.
  */
-int mctpSockSendRecv(const uint8_t eid, const bool mctpPreAllocTag,
+int mctpSockSendRecv(const uint8_t mctpNetworkId, const uint8_t eid,
+                     const bool mctpPreAllocTag,
                      const std::vector<uint8_t>& requestMsg,
                      void** responseMessage, size_t* responseMessageSize);
 
@@ -157,6 +159,7 @@ class CommandInterface
     pldm::InstanceIdDb instanceIdDb;
     uint8_t numRetries = 0;
     bool mctpPreAllocTag = false;
+    uint8_t mctpNetworkId = 1;
 };
 
 } // namespace helper

--- a/pldmtool/pldm_cmd_helper.hpp
+++ b/pldmtool/pldm_cmd_helper.hpp
@@ -9,7 +9,6 @@
 #include <libpldm/fru.h>
 #include <libpldm/platform.h>
 #include <linux/mctp.h>
-#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/poll.h>
 #include <sys/socket.h>

--- a/pldmtool/pldm_cmd_helper.hpp
+++ b/pldmtool/pldm_cmd_helper.hpp
@@ -8,6 +8,10 @@
 #include <libpldm/bios.h>
 #include <libpldm/fru.h>
 #include <libpldm/platform.h>
+#include <linux/mctp.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -72,16 +76,18 @@ void fillCompletionCode(uint8_t completionCode, ordered_json& data,
 
 /** @brief MCTP socket read/receive
  *
+ *  @param[in]  eid - mctp endpoint id
+ *  @mctpPreAllocTag - bool to indicate request for preallocated tag
  *  @param[in]  requestMsg - Request message to compare against loopback
  *              message received from mctp socket
  *  @param[out] responseMsg - Response buffer received from mctp socket
- *  @param[in]  pldmVerbose - verbosity flag - true/false
  *
  *  @return -   0 on success.
  *             -1 or -errno on failure.
  */
-int mctpSockSendRecv(const std::vector<uint8_t>& requestMsg,
-                     std::vector<uint8_t>& responseMsg, bool pldmVerbose);
+int mctpSockSendRecv(const uint8_t eid, const bool mctpPreAllocTag,
+                     const std::vector<uint8_t>& requestMsg,
+                     void** responseMessage, size_t* responseMessageSize);
 
 class CommandInterface
 {
@@ -150,6 +156,7 @@ class CommandInterface
     uint8_t instanceId;
     pldm::InstanceIdDb instanceIdDb;
     uint8_t numRetries = 0;
+    bool mctpPreAllocTag = false;
 };
 
 } // namespace helper

--- a/pldmtool/pldmtool.cpp
+++ b/pldmtool/pldmtool.cpp
@@ -85,6 +85,8 @@ class MctpRawOp : public CommandInterface
     explicit MctpRawOp(const char* type, const char* name, CLI::App* app) :
         CommandInterface(type, name, app)
     {
+        app->add_option("-e,--network-id", mctpNetworkId, "MCTP NetworkId")
+            ->required();
         app->add_option("-d,--data", rawData, "raw MCTP data")
             ->required()
             ->expected(-3);

--- a/requester/mctp_endpoint_discovery.cpp
+++ b/requester/mctp_endpoint_discovery.cpp
@@ -26,15 +26,16 @@ namespace pldm
 MctpDiscovery::MctpDiscovery(
     sdbusplus::bus_t& bus,
     std::initializer_list<MctpDiscoveryHandlerIntf*> list) :
-    bus(bus), mctpEndpointAddedSignal(
-                  bus, interfacesAdded(MCTPPath),
-                  std::bind_front(&MctpDiscovery::discoverEndpoints, this)),
+    bus(bus),
+    mctpEndpointAddedSignal(
+        bus, interfacesAdded(MCTPPath),
+        [this](sdbusplus::message_t& msg) { this->discoverEndpoints(msg); }),
     mctpEndpointRemovedSignal(
         bus, interfacesRemoved(MCTPPath),
-        std::bind_front(&MctpDiscovery::removeEndpoints, this)),
+        [this](sdbusplus::message_t& msg) { this->removeEndpoints(msg); }),
     mctpEndpointPropChangedSignal(
         bus, propertiesChangedNamespace(MCTPPath, MCTPInterfaceCC),
-        std::bind_front(&MctpDiscovery::propertiesChangedCb, this)),
+        [this](sdbusplus::message_t& msg) { this->propertiesChangedCb(msg); }),
     handlers(list)
 {
     std::map<MctpInfo, Availability> currentMctpInfoMap;

--- a/requester/request.hpp
+++ b/requester/request.hpp
@@ -49,7 +49,7 @@ class RequestRetryTimer
                                std::chrono::milliseconds timeout) :
 
         event(event), numRetries(numRetries), timeout(timeout),
-        timer(event.get(), std::bind_front(&RequestRetryTimer::callback, this))
+        timer(event.get(), [this] { this->callback(); })
     {}
 
     /** @brief Starts the request flow and arms the timer for request retries

--- a/requester/test/handler_test.cpp
+++ b/requester/test/handler_test.cpp
@@ -83,7 +83,9 @@ TEST_F(HandlerTest, singleRequestResponseScenario)
     EXPECT_EQ(instanceId, 0);
     auto rc = reqHandler.registerRequest(
         eid, instanceId, 0, 0, std::move(request),
-        std::bind_front(&HandlerTest::pldmResponseCallBack, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->pldmResponseCallBack(eid, response, respMsgLen);
+        });
     EXPECT_EQ(rc, PLDM_SUCCESS);
 
     pldm::Response response(sizeof(pldm_msg_hdr) + sizeof(uint8_t));
@@ -104,7 +106,9 @@ TEST_F(HandlerTest, singleRequestInstanceIdTimerExpired)
     EXPECT_EQ(instanceId, 0);
     auto rc = reqHandler.registerRequest(
         eid, instanceId, 0, 0, std::move(request),
-        std::bind_front(&HandlerTest::pldmResponseCallBack, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->pldmResponseCallBack(eid, response, respMsgLen);
+        });
     EXPECT_EQ(rc, PLDM_SUCCESS);
 
     // Waiting for 500ms so that the instance ID expiry callback is invoked
@@ -123,7 +127,9 @@ TEST_F(HandlerTest, multipleRequestResponseScenario)
     EXPECT_EQ(instanceId, 0);
     auto rc = reqHandler.registerRequest(
         eid, instanceId, 0, 0, std::move(request),
-        std::bind_front(&HandlerTest::pldmResponseCallBack, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->pldmResponseCallBack(eid, response, respMsgLen);
+        });
     EXPECT_EQ(rc, PLDM_SUCCESS);
 
     pldm::Request requestNxt{};
@@ -131,7 +137,9 @@ TEST_F(HandlerTest, multipleRequestResponseScenario)
     EXPECT_EQ(instanceIdNxt, 1);
     rc = reqHandler.registerRequest(
         eid, instanceIdNxt, 0, 0, std::move(requestNxt),
-        std::bind_front(&HandlerTest::pldmResponseCallBack, this));
+        [this](mctp_eid_t eid, const pldm_msg* response, size_t respMsgLen) {
+            this->pldmResponseCallBack(eid, response, respMsgLen);
+        });
     EXPECT_EQ(rc, PLDM_SUCCESS);
 
     pldm::Response response(sizeof(pldm_msg_hdr) + sizeof(uint8_t));

--- a/softoff/softoff.cpp
+++ b/softoff/softoff.cpp
@@ -39,7 +39,7 @@ namespace sdbusRule = sdbusplus::bus::match::rules;
 
 SoftPowerOff::SoftPowerOff(sdbusplus::bus_t& bus, sd_event* event,
                            pldm::InstanceIdDb& instanceIdDb) :
-    bus(bus), timer(event), instanceIdDb(instanceIdDb)
+    timer(event), instanceIdDb(instanceIdDb)
 {
     auto jsonData = parseConfig();
 

--- a/softoff/softoff.hpp
+++ b/softoff/softoff.hpp
@@ -148,9 +148,6 @@ class SoftPowerOff
      */
     bool responseReceived = false;
 
-    /* @brief sdbusplus handle */
-    sdbusplus::bus_t& bus;
-
     /** @brief Reference to Timer object */
     sdbusplus::Timer timer;
 


### PR DESCRIPTION
Including fixes related to recent failure reported due to regression/clang-version upgrade.
clang-tidy: replace C header with C++ equivalent
Fix build issues after migrating to Clang 20

CI verified with latest upstream openbmc CI.
