### PR TITLE
Add PDR Type 22 parser and JSON export support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,8 @@ executable(
     'platform-mc/numeric_sensor.cpp',
     'platform-mc/event_manager.cpp',
     'platform-mc/dbus_to_terminus_effecters.cpp',
+    'rde/redfish_resource_manager.cpp',
+    'rde/redfish_resource_pdr_view.cpp',
     oem_files,
     'requester/mctp_endpoint_discovery.cpp',
     implicit_include_directories: false,
@@ -299,5 +301,6 @@ if get_option('tests').allowed()
     subdir('host-bmc/test')
     subdir('requester/test')
     subdir('platform-mc/test')
+    subdir('rde/test')
     subdir('test')
 endif

--- a/rde/pdr_plat_helper.hpp
+++ b/rde/pdr_plat_helper.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <libpldm/platform.h>
+#include <libpldm/pldm.h>
+#include <libpldm/pldm_types.h>
+
+#include <cstdint>
+
+#pragma pack(push, 1)
+struct variable_len_field
+{
+    uint8_t* ptr;
+    uint16_t length;
+};
+
+struct oem_info_t
+{
+    uint8_t* name;
+    uint16_t name_length;
+};
+
+struct add_resrc_t
+{
+    uint32_t resrc_id;
+    uint16_t length;
+    uint8_t* name;
+};
+
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+struct pldm_redfish_resource_pdr
+{
+    struct pldm_value_pdr_hdr hdr;
+    uint32_t resource_id;
+    bitfield8_t resource_flags;
+    uint32_t cont_resrc_id;
+    uint16_t prop_cont_resrc_length;
+    uint8_t* prop_cont_resrc_name;
+    uint16_t sub_uri_length;
+    uint8_t* sub_uri_name;
+    uint16_t add_resrc_id_count;
+    struct add_resrc_t** additional_resrc;
+    ver32_t major_schema_version;
+    uint16_t major_schema_dict_length_bytes;
+    uint32_t major_schema_dict_signature;
+    struct variable_len_field major_schema;
+    uint16_t oem_count;
+    struct oem_info_t** oem_list;
+};
+#pragma pack(pop)

--- a/rde/redfish_resource_example.json
+++ b/rde/redfish_resource_example.json
@@ -1,0 +1,11 @@
+{
+    "Resources": {
+        "200": {
+            "ProposedContainingResourceName": "Processor",
+            "SubURI": "oem/amd/RDE/AmdSocConfiguration",
+            "MajorSchemaName": "Processor",
+            "MajorSchemaVersion": "1.1",
+            "OEMExtensions": ["OEM/VendorA", "OEM/VendorB"]
+        }
+    }
+}

--- a/rde/redfish_resource_manager.cpp
+++ b/rde/redfish_resource_manager.cpp
@@ -1,0 +1,140 @@
+#include "redfish_resource_manager.hpp"
+
+#include "pdr_plat_helper.hpp"
+#include "redfish_resource_pdr_view.hpp"
+
+#include <libpldm/platform.h>
+#include <libpldm/pldm.h>
+#include <libpldm/pldm_types.h>
+
+#include <phosphor-logging/lg2.hpp>
+
+PHOSPHOR_LOG2_USING;
+
+#include <cstring>
+#include <fstream>
+#include <span>
+
+namespace pldm::rde
+{
+
+RedfishResourceManager::RedfishResourceManager(pldm_pdr* pdrRepo,
+                                               uint32_t deviceID) :
+    pdrRepo(pdrRepo), deviceID(deviceID)
+{}
+
+std::vector<ResourceInfoView> RedfishResourceManager::extractResourcePDRs()
+{
+    uint8_t* outData = nullptr;
+    uint32_t size{};
+    const pldm_pdr_record* record{};
+    std::vector<ResourceInfoView> resourceViews;
+
+    try
+    {
+        do
+        {
+            record = pldm_pdr_find_record_by_type(
+                pdrRepo, PLDM_REDFISH_RESOURCE_PDR, record, &outData, &size);
+            if (record && outData && size > sizeof(pldm_value_pdr_hdr))
+            {
+                // Skip the common PDR header
+                uint8_t* payload = outData + sizeof(pldm_pdr_hdr);
+                size_t payloadSize = size - sizeof(pldm_pdr_hdr);
+
+                // Use the helper class to parse the payload
+                RedfishResourcePDRView view(payload, payloadSize);
+                ResourceInfoView info;
+
+                if (view.parse(info))
+                {
+                    resourceViews.push_back(std::move(info));
+                }
+                else
+                {
+                    error("Failed to parse PDR payload");
+                }
+            }
+        } while (record);
+    }
+    catch (const std::exception& e)
+    {
+        error("Failed to obtain a record, error - {ERROR}", "ERROR", e);
+    }
+
+    return resourceViews;
+}
+
+void RedfishResourceManager::populateStoredResources()
+{
+    std::vector<ResourceInfoView> views = extractResourcePDRs();
+
+    for (const auto& view : views)
+    {
+        std::vector<std::string> oemNames;
+        for (const auto& oem : view.oemNames)
+        {
+            oemNames.emplace_back(oem);
+        }
+
+        storedResources.emplace(
+            view.resourceID,
+            ResourceInfoView{
+                view.resourceID, std::string(view.propContainerName),
+                std::string(view.subURI), std::string(view.schemaName),
+                view.schemaVersion, std::move(oemNames)});
+    }
+}
+
+nlohmann::json RedfishResourceManager::buildJSONSchemaMap() const
+{
+    nlohmann::json jsonMap;
+    nlohmann::json resourcesJson;
+
+    for (const auto& [resourceID, resourceInfo] : storedResources)
+    {
+        nlohmann::json resourceJson;
+        resourceJson["ProposedContainingResourceName"] =
+            resourceInfo.propContainerName;
+        resourceJson["MajorSchemaName"] = resourceInfo.schemaName;
+        resourceJson["MajorSchemaVersion"] = resourceInfo.schemaVersion;
+        resourceJson["SubURI"] = resourceInfo.subURI;
+
+        // OEM Extensions
+        nlohmann::json oemJson = nlohmann::json::array();
+        for (const auto& oemName : resourceInfo.oemNames)
+        {
+            oemJson.push_back(oemName);
+        }
+        resourceJson["OEMExtensions"] = oemJson;
+
+        resourcesJson[std::to_string(resourceID)] = resourceJson;
+    }
+
+    jsonMap["Resources"] = resourcesJson;
+    return jsonMap;
+}
+
+void RedfishResourceManager::exportResourceSchemaToFile(
+    const std::string& filePath)
+{
+    // Populate internal resource map from PDRs
+    populateStoredResources();
+
+    // Build JSON schema map from stored resources
+    nlohmann::json jsonMap = buildJSONSchemaMap();
+
+    // Write JSON to file with pretty print
+    std::ofstream file(filePath);
+    if (file.is_open())
+    {
+        file << jsonMap.dump(4); // Indent with 4 spaces
+        file.close();
+    }
+    else
+    {
+        error("Failed to open file: {PATH}", "PATH", filePath.c_str());
+    }
+}
+
+} // namespace pldm::rde

--- a/rde/redfish_resource_manager.hpp
+++ b/rde/redfish_resource_manager.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "pdr_plat_helper.hpp"
+#include "redfish_resource_pdr_view.hpp"
+
+#include <libpldm/platform.h>
+#include <libpldm/pldm.h>
+#include <libpldm/pldm_types.h>
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace pldm::rde
+{
+
+/**
+ * @class RedfishResourceManager
+ * @brief Class to manage Redfish resources and actions.
+ *
+ * This class is responsible for parsing Redfish  PLDM PDRs and generating JSON
+ * schema maps for Redfish resources. It is designed to be extensible to support
+ * additional PDR types in the future.
+ */
+class RedfishResourceManager
+{
+  public:
+    /**
+     * @brief Constructor for the RedfishResourceManager class.
+     * @param pdrRepo Pointer to the PLDM PDR repository.
+     * @param deviceID ID of the device.
+     */
+    RedfishResourceManager(pldm_pdr* pdrRepo, uint32_t deviceID);
+    RedfishResourceManager(const RedfishResourceManager&) = default;
+    RedfishResourceManager& operator=(const RedfishResourceManager&) = default;
+    RedfishResourceManager(RedfishResourceManager&&) = default;
+    RedfishResourceManager& operator=(RedfishResourceManager&&) = default;
+
+    /**
+     * @brief Destructor for the RedfishResourceManager class.
+     */
+    virtual ~RedfishResourceManager() = default;
+
+    /**
+     * @brief Exports the resource schema to a JSON file.
+     *
+     * This function populates the internal resource map by extracting
+     * supported PDRs and then builds a JSON schema map. The resulting
+     * JSON is written to the specified file path.
+     *
+     * @param filePath Path to the output JSON file.
+     */
+    void exportResourceSchemaToFile(const std::string& filePath);
+
+    /**
+     * @brief Extracts structured resource information from supported PDR types.
+     *
+     * This function parses the Platform Descriptor Records (PDRs) repository
+     * and extracts structured resource metadata into a list of ResourceInfoView
+     * objects. It currently supports Redfish Resource PDRs, but is designed to
+     * be extended to handle additional PDR types in the future.
+     *
+     * @return A vector of ResourceInfoView structures representing the parsed
+     *         resource metadata from the PDR repository.
+     */
+    virtual std::vector<ResourceInfoView> extractResourcePDRs();
+
+  private:
+    /**
+     * @brief Populates the internal resource map with structured resource data.
+     *
+     * This function serves as a generic mechanism to populate the internal
+     * storedResources map with resource information extracted from Platform
+     * Descriptor Records (PDRs). It currently supports Redfish Resource PDRs
+     * by invoking the extractResourcePDRs() helper function.
+     *
+     * @note This function is designed to be extensible. In the future, it can
+     * be adapted to support additional PDR types or resource categories.
+     */
+    void populateStoredResources();
+
+    /**
+     * @brief Builds a JSON schema map from the extracted resources and actions.
+     * @return JSON schema map.
+     */
+    nlohmann::json buildJSONSchemaMap() const;
+
+    pldm_pdr* pdrRepo;                  // Pointer to the PLDM PDR repository.
+    [[maybe_unused]] uint32_t deviceID; // ID of the device.
+    std::unordered_map<uint32_t, ResourceInfoView>
+        storedResources;                // Map of stored resources.
+};
+
+} // namespace pldm::rde

--- a/rde/redfish_resource_pdr_view.cpp
+++ b/rde/redfish_resource_pdr_view.cpp
@@ -1,0 +1,101 @@
+#include "redfish_resource_pdr_view.hpp"
+
+#include <format>
+#include <ranges>
+
+namespace pldm::rde
+{
+
+RedfishResourcePDRView::RedfishResourcePDRView(const uint8_t* buffer,
+                                               size_t length) :
+    cursor(buffer), end(buffer + length)
+{}
+bool RedfishResourcePDRView::parse(ResourceInfoView& outView)
+{
+    if (!readUint32(outView.resourceID))
+        return false;
+
+    skip(RESOURCE_FLAGS_SIZE);
+    skip(CONTAINER_RESOURCE_ID_SIZE);
+
+    if (!readString(outView.propContainerName) || !readString(outView.subURI))
+        return false;
+
+    skip(ADD_RESR_ID_COUNT_SIZE);
+
+    uint8_t major, minor, update, alpha;
+    if (!readByte(major) || !readByte(minor) || !readByte(update) ||
+        !readByte(alpha))
+        return false;
+
+    skip(SCHEMA_DICT_LENGTH_SIZE);
+    skip(SCHEMA_DICT_SIGNATURE_SIZE);
+
+    if (!readString(outView.schemaName))
+        return false;
+
+    uint16_t oemCount;
+    if (!readUint16(oemCount))
+        return false;
+
+    for (auto _ : std::views::iota(0u, static_cast<unsigned>(oemCount)))
+    {
+        std::string oem;
+        if (!readString(oem))
+            return false;
+        outView.oemNames.push_back(std::move(oem));
+    }
+
+    outView.schemaVersion =
+        std::format("{}.{}.{}.{}", major, minor, update, alpha);
+    return true;
+}
+
+bool RedfishResourcePDRView::readByte(uint8_t& val)
+{
+    if (cursor + BYTE_SIZE > end)
+        return false;
+    val = *cursor++;
+    return true;
+}
+
+bool RedfishResourcePDRView::readUint16(uint16_t& val)
+{
+    if (cursor + UINT16_SIZE > end)
+        return false;
+    val = cursor[0] | (cursor[1] << SHIFT_BYTE_1);
+    cursor += UINT16_SIZE;
+    return true;
+}
+
+bool RedfishResourcePDRView::readUint32(uint32_t& val)
+{
+    if (cursor + UINT32_SIZE > end)
+        return false;
+    val = cursor[0] | (cursor[1] << SHIFT_BYTE_1) |
+          (cursor[2] << SHIFT_BYTE_2) | (cursor[3] << SHIFT_BYTE_3);
+    cursor += UINT32_SIZE;
+    return true;
+}
+
+bool RedfishResourcePDRView::readString(std::string& out)
+{
+    uint16_t len;
+    if (!readUint16(len))
+        return false;
+    if (cursor + len > end)
+        return false;
+    out.assign(reinterpret_cast<const char*>(cursor), len);
+    cursor += len;
+    return true;
+}
+
+void RedfishResourcePDRView::skip(size_t bytes)
+{
+    if (cursor + bytes <= end)
+        cursor += bytes;
+    else
+        cursor = end;
+}
+
+} // namespace pldm::rde

--- a/rde/redfish_resource_pdr_view.hpp
+++ b/rde/redfish_resource_pdr_view.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace pldm::rde
+{
+
+/**
+ * @struct ResourceInfoView
+ * @brief Holds parsed information from a Redfish resource PDR.
+ */
+struct ResourceInfoView
+{
+    uint32_t resourceID;
+    std::string propContainerName;
+    std::string subURI;
+    std::string schemaName;
+    std::string schemaVersion;
+    std::vector<std::string> oemNames;
+};
+
+// Constants used for parsing offsets
+inline constexpr size_t RESOURCE_FLAGS_SIZE = 1;
+inline constexpr size_t CONTAINER_RESOURCE_ID_SIZE = 4;
+inline constexpr size_t ADD_RESR_ID_COUNT_SIZE = 2;
+inline constexpr size_t SCHEMA_DICT_LENGTH_SIZE = 2;
+inline constexpr size_t SCHEMA_DICT_SIGNATURE_SIZE = 4;
+inline constexpr int SHIFT_BYTE_1 = 8;
+inline constexpr int SHIFT_BYTE_2 = 16;
+inline constexpr int SHIFT_BYTE_3 = 24;
+inline constexpr size_t BYTE_SIZE = 1;
+inline constexpr size_t UINT16_SIZE = 2;
+inline constexpr size_t UINT32_SIZE = 4;
+
+/**
+ * @class RedfishResourcePDRView
+ * @brief Parses Redfish PLDM PDR binary data into structured resource
+ * information.
+ *
+ * This class provides methods to parse binary-encoded Redfish resource PDRs and
+ * extract structured data such as resource identifiers, schema names, and OEM
+ * names.
+ */
+class RedfishResourcePDRView
+{
+  public:
+    RedfishResourcePDRView() = default;
+    RedfishResourcePDRView(const RedfishResourcePDRView&) = default;
+    RedfishResourcePDRView(RedfishResourcePDRView&&) = default;
+    RedfishResourcePDRView& operator=(const RedfishResourcePDRView&) = default;
+    RedfishResourcePDRView& operator=(RedfishResourcePDRView&&) = default;
+    RedfishResourcePDRView(const uint8_t* buffer, size_t length);
+
+    ~RedfishResourcePDRView() = default;
+
+    /**
+     * @brief Parses the binary data and populates the ResourceInfoView
+     * structure.
+     * @param outView Reference to the output structure to populate.
+     * @return True if parsing is successful, false otherwise.
+     */
+    bool parse(struct ResourceInfoView& outView);
+
+  private:
+    const uint8_t* cursor = nullptr;
+    const uint8_t* end = nullptr;
+
+    bool readByte(uint8_t& val);
+    bool readUint16(uint16_t& val);
+    bool readUint32(uint32_t& val);
+    bool readString(std::string& out);
+    void skip(size_t bytes);
+};
+
+} // namespace pldm::rde

--- a/rde/test/meson.build
+++ b/rde/test/meson.build
@@ -1,0 +1,34 @@
+rde_test_src = declare_dependency(
+    sources: [
+        '../redfish_resource_manager.cpp',
+        '../redfish_resource_pdr_view.cpp',
+        '../../common/utils.cpp',
+    ],
+)
+
+tests = ['redfish_resource_manager_test', 'redfish_resource_pdr_view_test']
+
+foreach t : tests
+    test(
+        t,
+        executable(
+            t.underscorify(),
+            t + '.cpp',
+            implicit_include_directories: false,
+            include_directories: '../../pldmd',
+            dependencies: [
+                rde_test_src,
+                gmock,
+                gtest,
+                libpldm_dep,
+                libpldmutils,
+                nlohmann_json_dep,
+                phosphor_dbus_interfaces,
+                phosphor_logging_dep,
+                sdbusplus,
+                sdeventplus,
+            ],
+        ),
+        workdir: meson.current_source_dir(),
+    )
+endforeach

--- a/rde/test/redfish_resource_manager_test.cpp
+++ b/rde/test/redfish_resource_manager_test.cpp
@@ -1,0 +1,86 @@
+#include "rde/redfish_resource_manager.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <ranges>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace pldm::rde;
+
+constexpr uint32_t kResourceID = 1001;
+const std::string kPropContainerName = "Power";
+const std::string kSubURI = "/redfish/v1/Chassis/1/Power";
+const std::string kSchemaName = "Power.v1_0_0";
+const std::string kSchemaVersion = "1.0.0.0";
+const std::vector<std::string> kOEMNames = {"OEM1", "OEM2"};
+
+// Mock subclass
+class MockRedfishResourceManager : public RedfishResourceManager
+{
+  public:
+    using RedfishResourceManager::RedfishResourceManager;
+
+    MOCK_METHOD(std::vector<ResourceInfoView>, extractResourcePDRs, (),
+                (override));
+};
+
+class RedfishResourceManagerTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        mockManager = std::make_unique<MockRedfishResourceManager>(
+            dummyPdrRepo, dummyDeviceID);
+    }
+
+    pldm_pdr* dummyPdrRepo = nullptr;
+    uint32_t dummyDeviceID = 42;
+    std::unique_ptr<MockRedfishResourceManager> mockManager;
+};
+
+TEST_F(RedfishResourceManagerTest, ExportResourceSchemaToFile)
+{
+    std::vector<ResourceInfoView> mockResources = {
+        {kResourceID, kPropContainerName, kSubURI, kSchemaName, kSchemaVersion,
+         kOEMNames}};
+
+    EXPECT_CALL(*mockManager, extractResourcePDRs())
+        .Times(1)
+        .WillOnce(testing::Return(mockResources));
+
+    std::string outputPath = "test_output_schema.json";
+    mockManager->exportResourceSchemaToFile(outputPath);
+
+    std::ifstream inFile(outputPath);
+    ASSERT_TRUE(inFile.is_open());
+
+    nlohmann::json jsonOutput;
+    inFile >> jsonOutput;
+    inFile.close();
+
+    ASSERT_FALSE(jsonOutput.empty());
+    ASSERT_TRUE(jsonOutput.is_object());
+
+    ASSERT_TRUE(jsonOutput.contains("Resources"));
+    const auto& resources = jsonOutput["Resources"];
+    ASSERT_TRUE(resources.contains(std::to_string(kResourceID)));
+    const auto& resource = resources[std::to_string(kResourceID)];
+
+    EXPECT_EQ(resource["ProposedContainingResourceName"], kPropContainerName);
+    EXPECT_EQ(resource["SubURI"], kSubURI);
+    EXPECT_EQ(resource["MajorSchemaName"], kSchemaName);
+    EXPECT_EQ(resource["MajorSchemaVersion"], kSchemaVersion);
+
+    ASSERT_TRUE(resource["OEMExtensions"].is_array());
+    EXPECT_EQ(resource["OEMExtensions"].size(), kOEMNames.size());
+
+    for (auto [i, oem] : std::views::enumerate(kOEMNames))
+    {
+        EXPECT_EQ(resource["OEMExtensions"][i], oem);
+    }
+
+    std::remove(outputPath.c_str());
+}

--- a/rde/test/redfish_resource_pdr_view_test.cpp
+++ b/rde/test/redfish_resource_pdr_view_test.cpp
@@ -1,0 +1,126 @@
+#include "rde/redfish_resource_pdr_view.hpp"
+
+#include <libpldm/platform.h>
+
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace pldm::rde;
+
+// Constants for mock data
+constexpr uint32_t kResourceID = 1;
+constexpr uint8_t kResourceFlags = 0x00;
+constexpr uint32_t kContainerResourceID = 0;
+const std::string kPropContainerName = "Contai";
+const std::string kSubURI = "subURI";
+const std::string kSchemaName = "Schema";
+constexpr uint8_t kSchemaMajor = 1;
+constexpr uint8_t kSchemaMinor = 0;
+constexpr uint8_t kSchemaUpdate = 0;
+constexpr uint8_t kSchemaAlpha = 0;
+constexpr uint16_t kSchemaDictLength = 0;
+constexpr uint32_t kSchemaDictSignature = 0;
+constexpr uint16_t kOEMCount = 2;
+const std::vector<std::string> kOEMNames = {"OEM1", "OEM2"};
+
+// Helper to encode a string with a 2-byte length prefix
+void encodeString(std::vector<uint8_t>& buffer, const std::string& str)
+{
+    uint16_t len = static_cast<uint16_t>(str.size());
+    buffer.push_back(static_cast<uint8_t>(len & 0xFF));
+    buffer.push_back(static_cast<uint8_t>((len >> SHIFT_BYTE_1) & 0xFF));
+    buffer.insert(buffer.end(), str.begin(), str.end());
+}
+
+// Build a mock Redfish Resource PDR payload
+std::vector<uint8_t> buildMockRedfishResourcePDR()
+{
+    std::vector<uint8_t> buffer;
+
+    // Resource ID
+    buffer.push_back(static_cast<uint8_t>(kResourceID & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kResourceID >> SHIFT_BYTE_1) & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kResourceID >> SHIFT_BYTE_2) & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kResourceID >> SHIFT_BYTE_3) & 0xFF));
+
+    // Resource Flags
+    buffer.push_back(kResourceFlags);
+
+    // Container Resource ID
+    buffer.push_back(static_cast<uint8_t>(kContainerResourceID & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kContainerResourceID >> SHIFT_BYTE_1) & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kContainerResourceID >> SHIFT_BYTE_2) & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kContainerResourceID >> SHIFT_BYTE_3) & 0xFF));
+
+    // Property Container Name
+    encodeString(buffer, kPropContainerName);
+
+    // SubURI
+    encodeString(buffer, kSubURI);
+
+    // Add Resource ID Count (2 bytes, skipped)
+    buffer.push_back(0x00);
+    buffer.push_back(0x00);
+
+    // Schema Version
+    buffer.push_back(kSchemaMajor);
+    buffer.push_back(kSchemaMinor);
+    buffer.push_back(kSchemaUpdate);
+    buffer.push_back(kSchemaAlpha);
+
+    // Schema Dict Length (2 bytes, skipped)
+    buffer.push_back(static_cast<uint8_t>(kSchemaDictLength & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kSchemaDictLength >> SHIFT_BYTE_1) & 0xFF));
+
+    // Schema Dict Signature (4 bytes, skipped)
+    buffer.push_back(static_cast<uint8_t>(kSchemaDictSignature & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kSchemaDictSignature >> SHIFT_BYTE_1) & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kSchemaDictSignature >> SHIFT_BYTE_2) & 0xFF));
+    buffer.push_back(
+        static_cast<uint8_t>((kSchemaDictSignature >> SHIFT_BYTE_3) & 0xFF));
+
+    // Schema Name
+    encodeString(buffer, kSchemaName);
+
+    // OEM Count
+    buffer.push_back(static_cast<uint8_t>(kOEMCount & 0xFF));
+    buffer.push_back(static_cast<uint8_t>((kOEMCount >> SHIFT_BYTE_1) & 0xFF));
+
+    // OEM Names
+    for (const auto& oem : kOEMNames)
+    {
+        encodeString(buffer, oem);
+    }
+
+    return buffer;
+}
+
+TEST(RedfishResourcePDRViewTest, ParseValidPayload)
+{
+    auto payload = buildMockRedfishResourcePDR();
+    ResourceInfoView view;
+    RedfishResourcePDRView parser(payload.data(), payload.size());
+
+    ASSERT_TRUE(parser.parse(view));
+    EXPECT_EQ(view.resourceID, kResourceID);
+    EXPECT_EQ(view.propContainerName, kPropContainerName);
+    EXPECT_EQ(view.subURI, kSubURI);
+    EXPECT_EQ(view.schemaName, kSchemaName);
+    EXPECT_EQ(view.schemaVersion, "1.0.0.0");
+    ASSERT_EQ(view.oemNames.size(), kOEMNames.size());
+    EXPECT_EQ(view.oemNames[0], kOEMNames[0]);
+    EXPECT_EQ(view.oemNames[1], kOEMNames[1]);
+}


### PR DESCRIPTION
 This commit introduces support for parsing Redfish PLDM PDR Type 22
data and exporting it as structured JSON. The RedfishResourcePDRView class is responsible for interpreting the binary PDR data, while the RedfishResourceManager class manages the parsed resources and generates a JSON representation. The exported JSON includes key metadata such as resource ID, schema name and version, OEM extensions, and URI mappings.

 The design follows a scalable and maintainable approach by generating
the JSON output on demand through a dedicated function (exportResourceSchemaToFile) rather than during object construction. This ensures a clear separation of concerns, avoids unnecessary computation during object initialization, and allows for future enhancements such as caching or conditional exports.

 An example JSON file is included to demonstrate the expected output
format and structure, which can serve as a reference for integration and testing