### PR TITLE
platform-mc: Add redfish resource PDR handling

### DIFF
--- a/platform-mc/terminus.cpp
+++ b/platform-mc/terminus.cpp
@@ -191,6 +191,20 @@ void Terminus::parseTerminusPDRs()
                 entityAuxiliaryNamesTbl.emplace_back(std::move(entityNames));
                 break;
             }
+            case PLDM_REDFISH_RESOURCE_PDR:
+            {
+                auto parsedPdr = parseRedfishResourcePDR(pdr);
+                if (!parsedPdr)
+                {
+                    lg2::error(
+                        "Failed to parse PDR with type {TYPE} handle {HANDLE}",
+                        "TYPE", pdrHdr->type, "HANDLE",
+                        static_cast<uint32_t>(pdrHdr->record_handle));
+                    continue;
+                }
+                redfishResourcePdrs.emplace_back(std::move(parsedPdr));
+                break;
+            }
             default:
             {
                 lg2::error("Unsupported PDR with type {TYPE} handle {HANDLE}",
@@ -410,6 +424,20 @@ std::shared_ptr<pldm_numeric_sensor_value_pdr> Terminus::parseNumericSensorPDR(
     const uint8_t* ptr = pdr.data();
     auto parsedPdr = std::make_shared<pldm_numeric_sensor_value_pdr>();
     auto rc = decode_numeric_sensor_pdr_data(ptr, pdr.size(), parsedPdr.get());
+    if (rc)
+    {
+        return nullptr;
+    }
+    return parsedPdr;
+}
+
+std::shared_ptr<pldm_redfish_resource_pdr> Terminus::parseRedfishResourcePDR(
+    const std::vector<uint8_t>& pdr)
+{
+    const uint8_t* ptr = pdr.data();
+    auto parsedPdr = std::make_shared<pldm_redfish_resource_pdr>();
+    auto rc =
+        decode_redfish_resource_pdr_data(ptr, pdr.size(), parsedPdr.get());
     if (rc)
     {
         return nullptr;

--- a/platform-mc/terminus.hpp
+++ b/platform-mc/terminus.hpp
@@ -243,6 +243,14 @@ class Terminus
     std::shared_ptr<EntityAuxiliaryNames> parseEntityAuxiliaryNamesPDR(
         const std::vector<uint8_t>& pdrData);
 
+    /** @brief Parse the redfish resource PDRs
+     *
+     *  @param[in] pdrData - the response PDRs from GetPDR command
+     *  @return pointer to redfish resource info struct
+     */
+    std::shared_ptr<pldm_redfish_resource_pdr> parseRedfishResourcePDR(
+        const std::vector<uint8_t>& pdrData);
+
     /** @brief Construct the NumericSensor sensor class for the compact numeric
      *         PLDM sensor.
      *
@@ -341,6 +349,10 @@ class Terminus
     /** @brief Compact Numeric Sensor PDR list */
     std::vector<std::shared_ptr<pldm_compact_numeric_sensor_pdr>>
         compactNumericSensorPdrs{};
+
+    /** @brief Redfish Resource PDR list */
+    std::vector<std::shared_ptr<pldm_redfish_resource_pdr>>
+        redfishResourcePdrs{};
 
     /** @brief Iteration to loop through sensor PDRs when adding sensors */
     SensorId sensorPdrIt = 0;


### PR DESCRIPTION
This commit adds the following changes for enabling Redfish resource (type-22) within the pldm daemon.
- Added support to handle PDR data for redfish resource PDR.
- Added parse PDR member functions to terminus class for parsing redfish resource PDR.