### PR TITLE
pldmtool: Update RDEOperationComplete to print cc

### DIFF
--- a/pldmtool/pldm_rde_cmd.cpp
+++ b/pldmtool/pldm_rde_cmd.cpp
@@ -814,6 +814,10 @@ class RDEOperationComplete : public CommandInterface
                       << std::endl;
             return;
         }
+        ordered_json jsonData;
+        jsonData["CompletionCode"] = decodedCompletionCode;
+
+        pldmtool::helper::DisplayInJson(jsonData);
     }
 
   private:


### PR DESCRIPTION
RDEOperationComplete command do not have respone data, so printing completion code.

Tests:
CI: build pass.
HW: Verified on HW, below is the response.

'''
pldmtool rde RDEOperationComplete -r 700  -i 10 -m 12 -v
pldmtool: Tx: 80 06 13 bc 02 00 00 0a 00
pldmtool: Rx: 00 06 13 00
{
    "CompletionCode": 0
}
'''

Signed-off-by: Raja Sekhar Reddy Gade <rajagade@amd.com>