### PR TITLE
RDE: Infrastructre and Discovery support

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -544,6 +544,30 @@ int emitStateSensorEventSignal(uint8_t tid, uint16_t sensorId,
     return PLDM_SUCCESS;
 }
 
+int emitDiscoveryCompleteSignal(
+    uint8_t tid, const std::vector<std::vector<uint8_t>>& pdrPayloads)
+{
+    try
+    {
+        auto& bus = DBusHandler::getBus();
+        auto msg = bus.new_signal("/xyz/openbmc_project/pldm",
+                                  "xyz.openbmc_project.PLDM.Event",
+                                  "DiscoveryComplete");
+
+        msg.append(tid);
+        msg.append(pdrPayloads);
+        msg.signal_send();
+    }
+    catch (const std::exception& e)
+    {
+        error("Failed to emit PLDM DiscoveryComplete signal, error - {ERROR}",
+              "ERROR", e);
+        return PLDM_ERROR;
+    }
+
+    return PLDM_SUCCESS;
+}
+
 void recoverMctpEndpoint(const std::string& endpointObjPath)
 {
     auto& bus = DBusHandler::getBus();

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -508,6 +508,26 @@ int emitStateSensorEventSignal(uint8_t tid, uint16_t sensorId,
                                uint8_t previousEventState);
 
 /**
+ * @brief Emit a D-Bus signal indicating Redfish PDR discovery is complete
+ *
+ * Emits a signal with the terminus ID and a list of parsed Redfish Resource
+ * PDRs, each represented as a byte array suitable for D-Bus transmission.
+ *
+ * D-Bus Signature: DiscoveryComplete(uint8_t terminusId, array<array<byte>>
+ * pdrPayloads)
+ *
+ * @param tid[in] Terminus ID from which the PDRs were discovered
+ * @param pdrPayloads[in] Vector of raw Redfish Resource PDR payloads,
+ *        each PDR as a vector of bytes (std::vector<uint8_t>)
+ * @return int Returns PLDM_SUCCESS on success, or PLDM_ERROR on failure.
+ *
+ * @exception Logs an error message if the signal emission fails due to an
+ * exception.
+ */
+int emitDiscoveryCompleteSignal(
+    uint8_t tid, const std::vector<std::vector<uint8_t>>& pdrPayloads);
+
+/**
  *  @brief call Recover() method to recover an MCTP Endpoint
  *  @param[in] MCTP Endpoint's object path
  */

--- a/meson.build
+++ b/meson.build
@@ -258,6 +258,7 @@ executable(
     'platform-mc/event_manager.cpp',
     'platform-mc/dbus_to_terminus_effecters.cpp',
     'rde/dictionary.cpp',
+    'rde/dictionary_manager.cpp',
     'rde/manager.cpp',
     oem_files,
     'requester/mctp_endpoint_discovery.cpp',

--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,7 @@ executable(
     'platform-mc/numeric_sensor.cpp',
     'platform-mc/event_manager.cpp',
     'platform-mc/dbus_to_terminus_effecters.cpp',
+    'rde/dictionary.cpp',
     'rde/manager.cpp',
     oem_files,
     'requester/mctp_endpoint_discovery.cpp',

--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,7 @@ executable(
     'platform-mc/numeric_sensor.cpp',
     'platform-mc/event_manager.cpp',
     'platform-mc/dbus_to_terminus_effecters.cpp',
+    'rde/manager.cpp',
     oem_files,
     'requester/mctp_endpoint_discovery.cpp',
     implicit_include_directories: false,

--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,7 @@ executable(
     'platform-mc/numeric_sensor.cpp',
     'platform-mc/event_manager.cpp',
     'platform-mc/dbus_to_terminus_effecters.cpp',
+    'rde/device.cpp',
     'rde/dictionary.cpp',
     'rde/dictionary_manager.cpp',
     'rde/manager.cpp',

--- a/meson.build
+++ b/meson.build
@@ -260,6 +260,7 @@ executable(
     'rde/dictionary.cpp',
     'rde/dictionary_manager.cpp',
     'rde/manager.cpp',
+    'rde/resource_registry.cpp',
     oem_files,
     'requester/mctp_endpoint_discovery.cpp',
     implicit_include_directories: false,

--- a/platform-mc/platform_manager.cpp
+++ b/platform-mc/platform_manager.cpp
@@ -1,5 +1,6 @@
 #include "platform_manager.hpp"
 
+#include "common/utils.hpp"
 #include "manager.hpp"
 #include "terminus_manager.hpp"
 
@@ -110,6 +111,14 @@ exec::task<int> PlatformManager::initTerminus()
                 "TID", tid, "ERROR", rc);
         }
         terminus->initialized = true;
+
+        const auto redfishResources = terminus->getRedfishResourcePdrsRaw();
+
+        if (!redfishResources.empty())
+        {
+            pldm::utils::emitDiscoveryCompleteSignal(tid, redfishResources);
+        }
+
         if (manager)
         {
             manager->startSensorPolling(tid);

--- a/platform-mc/terminus.cpp
+++ b/platform-mc/terminus.cpp
@@ -203,6 +203,7 @@ void Terminus::parseTerminusPDRs()
                     continue;
                 }
                 redfishResourcePdrs.emplace_back(std::move(parsedPdr));
+                redfishResourcePdrsRaw.emplace_back(pdr);
                 break;
             }
             default:

--- a/platform-mc/terminus.hpp
+++ b/platform-mc/terminus.hpp
@@ -203,6 +203,22 @@ class Terminus
      */
     std::shared_ptr<NumericSensor> getSensorObject(SensorId id);
 
+    /**
+     * @brief Retrieve the list of raw Redfish Resource PDR payloads.
+     *
+     * This function returns a reference to the collection of raw Redfish
+     * Resource PDR records stored as byte vectors. Each element in the returned
+     * vector represents a complete PDR structure as received from the
+     * repository, and only those that have been successfully parsed.
+     *
+     * @return const std::vector<std::vector<uint8_t>>&
+     *         A reference to the raw Redfish Resource PDR payloads.
+     */
+    const std::vector<std::vector<uint8_t>>& getRedfishResourcePdrsRaw() const
+    {
+        return redfishResourcePdrsRaw;
+    }
+
   private:
     /** @brief Find the Terminus Name from the Entity Auxiliary name list
      *         The Entity Auxiliary name list is entityAuxiliaryNamesTbl.
@@ -353,6 +369,9 @@ class Terminus
     /** @brief Redfish Resource PDR list */
     std::vector<std::shared_ptr<pldm_redfish_resource_pdr>>
         redfishResourcePdrs{};
+
+    /** @brief  Redfish Resource PDR list blob **/
+    std::vector<std::vector<uint8_t>> redfishResourcePdrsRaw;
 
     /** @brief Iteration to loop through sensor PDRs when adding sensors */
     SensorId sensorPdrIt = 0;

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -7,6 +7,7 @@
 #include "invoker.hpp"
 #include "platform-mc/dbus_to_terminus_effecters.hpp"
 #include "platform-mc/manager.hpp"
+#include "rde/manager.hpp"
 #include "requester/handler.hpp"
 #include "requester/mctp_endpoint_discovery.hpp"
 #include "requester/request.hpp"
@@ -339,12 +340,15 @@ int main(int argc, char** argv)
 
 #endif
 
+    std::unique_ptr<pldm::rde::Manager> rdeManager =
+        std::make_unique<pldm::rde::Manager>(bus, &instanceIdDb, &reqHandler);
     std::unique_ptr<fw_update::Manager> fwManager =
         std::make_unique<fw_update::Manager>(event, reqHandler, instanceIdDb);
     std::unique_ptr<MctpDiscovery> mctpDiscoveryHandler =
         std::make_unique<MctpDiscovery>(
             bus, std::initializer_list<MctpDiscoveryHandlerIntf*>{
-                     fwManager.get(), platformManager.get()});
+                     fwManager.get(), platformManager.get(), rdeManager.get()});
+
     auto callback = [verbose, &invoker, &reqHandler, &fwManager, &pldmTransport,
                      TID](IO& io, int fd, uint32_t revents) mutable {
         if (!(revents & EPOLLIN))

--- a/rde/device.cpp
+++ b/rde/device.cpp
@@ -1,0 +1,196 @@
+#include "device.hpp"
+
+#include <filesystem>
+#include <iostream>
+
+namespace pldm::rde
+{
+Device::Device(sdbusplus::bus::bus& bus, const std::string& path,
+               pldm::InstanceIdDb* instanceIdDb,
+               pldm::requester::Handler<pldm::requester::Request>* handler,
+               const pldm::eid devEid, const pldm_tid_t tid,
+               const pldm::UUID& uuid,
+               const std::vector<std::vector<uint8_t>>& pdrPayloads) :
+    EntryIfaces(bus, path.c_str()), instanceIdDb_(instanceIdDb),
+    handler_(handler), tid_(tid), pdrPayloads_(pdrPayloads),
+    currentState_(DeviceState::NotReady)
+{
+    info(
+        "RDE : device Object creating device UUID:{UUID} EID:{EID} Path:{PATH}",
+        "UUID", uuid, "EID", static_cast<int>(devEid), "PATH", path);
+
+    this->eid(devEid);
+    this->deviceUUID(uuid);
+    this->name("Device_" + std::to_string(devEid));
+    this->negotiationStatus(NegotiationStatus::NotStarted);
+}
+
+Device::~Device()
+{
+    info("RDE: D-Bus Device object destroyed");
+}
+
+void Device::refreshDeviceInfo()
+{
+    info("RDE : Refreshing device EID:{EID}", "EID", static_cast<int>(eid()));
+
+    try
+    {
+        resourceRegistry_ = std::make_unique<ResourceRegistry>();
+        resourceRegistry_->loadFromResourcePDR(pdrPayloads_);
+        schemaResources(buildSchemaResourcesPayload());
+
+        dictionaryManager_ =
+            std::make_unique<pldm::rde::DictionaryManager>(deviceUUID());
+    }
+    catch (const std::exception& e)
+    {
+        error("Failed to initialize the objects: Msg{MSG}", "MSG", e.what());
+    }
+
+    info("Discovery is in progress");
+
+    // Placeholder for actual refresh logic
+    std::map<std::string,
+             std::variant<std::string, uint16_t, uint32_t, uint8_t>>
+        changed;
+    changed["Name"] = this->name();
+    deviceUpdated();
+}
+
+Metadata& Device::getMetadata()
+{
+    return metaData_;
+}
+
+void Device::setMetadata(const Metadata& meta)
+{
+    metaData_ = meta;
+}
+
+MetadataVariant Device::getMetadataField(const std::string& key) const
+{
+    if (key == "devProviderName")
+        return metaData_.devProviderName;
+    if (key == "etag")
+        return metaData_.etag;
+    if (key == "devConfigSignature")
+        return metaData_.devConfigSignature;
+    if (key == "mcMaxTransferChunkSizeBytes")
+        return metaData_.mcMaxTransferChunkSizeBytes;
+    if (key == "devMaxTransferChunkSizeBytes")
+        return metaData_.devMaxTransferChunkSizeBytes;
+    if (key == "mcConcurrencySupport")
+        return metaData_.mcConcurrencySupport;
+    if (key == "deviceConcurrencySupport")
+        return metaData_.deviceConcurrencySupport;
+    if (key == "protocolVersion")
+        return metaData_.protocolVersion;
+    if (key == "encoding")
+        return metaData_.encoding;
+    if (key == "sessionId")
+        return metaData_.sessionId;
+    if (key == "mcFeatureSupport")
+        return metaData_.mcFeatureSupport;
+    if (key == "devFeatureSupport")
+        return metaData_.devFeatureSupport;
+    if (key == "devCapabilities")
+        return metaData_.devCapabilities;
+    return std::string{};
+}
+
+void Device::setMetadataField(const std::string& key,
+                              const MetadataVariant& value)
+{
+    try
+    {
+        if (key == "devProviderName")
+            metaData_.devProviderName = std::get<std::string>(value);
+        else if (key == "etag")
+            metaData_.etag = std::get<std::string>(value);
+        else if (key == "devConfigSignature")
+            metaData_.devConfigSignature = std::get<uint32_t>(value);
+        else if (key == "mcMaxTransferChunkSizeBytes")
+            metaData_.mcMaxTransferChunkSizeBytes = std::get<uint32_t>(value);
+        else if (key == "devMaxTransferChunkSizeBytes")
+            metaData_.devMaxTransferChunkSizeBytes = std::get<uint32_t>(value);
+        else if (key == "deviceConcurrencySupport")
+            metaData_.deviceConcurrencySupport = std::get<uint8_t>(value);
+        else if (key == "mcConcurrencySupport")
+            metaData_.mcConcurrencySupport = std::get<uint8_t>(value);
+        else if (key == "protocolVersion")
+            metaData_.protocolVersion = std::get<std::string>(value);
+        else if (key == "encoding")
+            metaData_.encoding = std::get<std::string>(value);
+        else if (key == "sessionId")
+            metaData_.sessionId = std::get<std::string>(value);
+        else if (key == "mcFeatureSupport")
+            metaData_.mcFeatureSupport = std::get<FeatureSupport>(value);
+        else if (key == "devFeatureSupport")
+            metaData_.devFeatureSupport = std::get<FeatureSupport>(value);
+        else if (key == "devCapabilities")
+            metaData_.devCapabilities = std::get<DeviceCapabilities>(value);
+        else
+            error("Unknown metadata key:{KEY}", "KEY", key);
+    }
+    catch (const std::bad_variant_access& ex)
+    {
+        error("Metadata type mismatch for key {KEY}: {WHAT}", "KEY", key,
+              "WHAT", ex.what());
+    }
+    catch (const std::exception& ex)
+    {
+        error("Failed to set metadata key {KEY}: {WHAT}", "KEY", key, "WHAT",
+              ex.what());
+    }
+}
+
+DeviceState Device::getState() const
+{
+    return currentState_;
+}
+
+void Device::updateState(DeviceState newState)
+{
+    currentState_ = newState;
+}
+
+SchemaResourcesType Device::buildSchemaResourcesPayload() const
+{
+    SchemaResourcesType payload;
+
+    if (!resourceRegistry_)
+        return payload;
+
+    const auto& resourceMap = resourceRegistry_->getResourceMap();
+
+    for (const auto& [resourceId, info] : resourceMap)
+    {
+        PropertyMap entry;
+
+        // Canonical schema keys from SchemaResourceKeys definition
+        entry["subUri"] = info.uri;
+        entry["schemaName"] = info.schemaName;
+        entry["schemaVersion"] = info.schemaVersion;
+        entry["schemaClass"] = static_cast<int64_t>(info.schemaClass);
+        entry["ProposedContainingResourceName"] = info.propContainResourceName;
+        entry["operations"] =
+            static_cast<int64_t>(info.operations.size()); // Count for now
+
+        // Optional/OEM extensions: placeholders (can be populated when
+        // available)
+        entry["OEMExtensions"] =
+            std::string{}; // Replace with actual logic if applicable
+        entry["Actions"] =
+            std::string{}; // Replace with action serialization when added
+        entry["ActionName"] =
+            std::string{}; // Optional if action metadata is tracked
+        entry["ActionPath"] = std::string{}; // Optional action URI
+
+        payload[resourceId] = std::move(entry);
+    }
+
+    return payload;
+}
+
+} // namespace pldm::rde

--- a/rde/device.hpp
+++ b/rde/device.hpp
@@ -1,0 +1,200 @@
+#pragma once
+
+#include "device_common.hpp"
+#include "dictionary_manager.hpp"
+#include "resource_registry.hpp"
+#include "xyz/openbmc_project/Common/UUID/server.hpp"
+#include "xyz/openbmc_project/RDE/Device/server.hpp"
+
+#include <libpldm/base.h>
+
+#include <common/instance_id.hpp>
+#include <common/types.hpp>
+#include <requester/handler.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/source/event.hpp>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+namespace pldm::rde
+{
+
+using VariantValue = std::variant<int64_t, std::string>;
+using PropertyMap = std::map<std::string, VariantValue>;
+using SchemaResourcesType = std::map<std::string, PropertyMap>;
+
+using EntryIfaces = sdbusplus::server::object_t<
+    sdbusplus::xyz::openbmc_project::RDE::server::Device,
+    sdbusplus::xyz::openbmc_project::Common::server::UUID>;
+
+/**
+ * @class Device
+ * @brief Represents a Redfish-capable device managed via D-Bus.
+ */
+class Device : public EntryIfaces
+{
+  public:
+    /**
+     * @brief Constructor
+     * @param[in] bus - The D-Bus bus object
+     * @param[in] path - The D-Bus object path
+     * @param[in] instanceIdDb  Pointer to the instance ID database used for
+     *                          PLDM message tracking.
+     * @param[in] handler       Pointer to the PLDM request handler for sending
+     *                          and receiving messages.
+
+     * @param[in] eid -  MCTP Endpoint ID used in PLDM stack
+     * @param[in] tid - Target ID used in PLDM stack.
+     * @param[in] uuid - Internal registration identifier.
+     * @param[in] pdrPayloads Vector of raw Redfish Resource PDR payloads,
+     *           each PDR as a vector of bytes (std::vector<uint8_t>)
+     */
+    Device(sdbusplus::bus::bus& bus, const std::string& path,
+           pldm::InstanceIdDb* instanceIdDb,
+           pldm::requester::Handler<pldm::requester::Request>* handler,
+           const pldm::eid devEid, const pldm_tid_t tid, const pldm::UUID& uuid,
+           const std::vector<std::vector<uint8_t>>& pdrPayloads);
+
+    // Defaulted special member functions
+    Device() = delete;
+    Device(const Device&) = delete;
+    Device(Device&&) = delete;
+    Device& operator=(const Device&) = delete;
+    Device& operator=(Device&&) = delete;
+    virtual ~Device();
+
+    /**
+     * @brief Refreshes and updates capability and schema metadata from the
+     * device.
+     */
+    void refreshDeviceInfo() override;
+
+    /**
+     * @brief Access the device metadata.
+     * @return Reference to metadata.
+     */
+    Metadata& getMetadata();
+
+    /**
+     * @brief Set the device metadata.
+     * @param[in] meta Metadata to assign.
+     */
+    void setMetadata(const Metadata& meta);
+
+    /**
+     * @brief Get metadata field by key.
+     *
+     * This function retrieves an individual metadata field using its string
+     * key. Supported types include: std::string, uint8_t, uint16_t, uint32_t,
+     * FeatureSupport, and DeviceCapabilities.
+     *
+     * @param[in] key Metadata field name.
+     * @return Variant holding the value of the metadata field.
+     */
+    MetadataVariant getMetadataField(const std::string& key) const;
+
+    /**
+     * @brief Set metadata field by key.
+     *
+     * This function assigns a value to a metadata field using its string key.
+     * Supported types include: std::string, uint8_t, uint16_t, uint32_t,
+     * FeatureSupport, and DeviceCapabilities.
+     *
+     * @param[in] key Metadata field name.
+     * @param[in] value Variant containing the new value to set.
+     */
+    void setMetadataField(const std::string& key, const MetadataVariant& value);
+
+    /**
+     * @brief Returns reference to the PLDM instance ID database.
+     * @return Reference to pldm::InstanceIdDb
+     */
+    inline pldm::InstanceIdDb& getInstanceIdDb()
+    {
+        return *instanceIdDb_;
+    }
+
+    /**
+     * @brief Returns a pointer to the PLDM request handler.
+     * @return Pointer to Handler of PLDM Request
+     */
+    inline pldm::requester::Handler<pldm::requester::Request>* getHandler()
+    {
+        return handler_;
+    }
+
+    /**
+     * @brief Returns Terminus ID (TID).
+     * @return 8-bit unsigned integer TID value
+     */
+    inline uint8_t getTid() const
+    {
+        return tid_;
+    }
+
+    /**
+     * @brief Attempts to update the device state.
+     * @param newState The desired DeviceState.
+     */
+    void updateState(DeviceState newState);
+
+    /**
+     * @brief Returns the current device state.
+     */
+    DeviceState getState() const;
+
+    /**
+     * @brief Retrieve a non-owning pointer to the ResourceRegistry.
+     *
+     * @return Raw pointer to ResourceRegistry, or nullptr if not initialized.
+     */
+    ResourceRegistry* getRegistry()
+    {
+        return resourceRegistry_.get();
+    }
+
+    /**
+     * @brief Retrieve a non-owning pointer to the DictionaryManager.
+     *
+     * @return Raw pointer to DictionaryManager, or nullptr if not initialized.
+     */
+    DictionaryManager* getDictionary()
+    {
+        return dictionaryManager_.get();
+    }
+
+  private:
+    /**
+     * @brief Constructs schema resource payload based on discovered resources.
+     *
+     * Iterates through the registry and transforms each ResourceInfo into a
+     * property map keyed by canonical field names (defined by
+     * SchemaResourceKeys).
+     *
+     * Includes metadata such as subUri, schemaName, schemaVersion, schemaClass,
+     * operations count, container name, and placeholders for extensions or
+     * actions.
+     *
+     * @return A schema resource map suitable for D-Bus publication.
+     */
+    SchemaResourcesType buildSchemaResourcesPayload() const;
+
+    Metadata metaData_;
+    pldm::InstanceIdDb* instanceIdDb_ = nullptr;
+    pldm::requester::Handler<pldm::requester::Request>* handler_ = nullptr;
+    uint8_t tid_;
+    /** @brief  Redfish Resource PDR list blob **/
+    std::vector<std::vector<uint8_t>> pdrPayloads_;
+    DeviceState currentState_;
+    std::unique_ptr<ResourceRegistry> resourceRegistry_;
+    std::unique_ptr<pldm::rde::DictionaryManager> dictionaryManager_;
+};
+
+} // namespace pldm::rde

--- a/rde/device_common.hpp
+++ b/rde/device_common.hpp
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <libpldm/pldm_types.h>
+
+#include <cstdint>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace pldm::rde
+{
+
+/**
+ * @enum DeviceState
+ * @brief Represents the lifecycle state of an RDE-managed device.
+ * It is owned and updated by the Device class, but may be influenced by
+ * session outcomes.
+ */
+enum class DeviceState
+{
+    NotReady,    // Not initialized
+    Discovering, // Actively probing device via RDE discovery
+    Operational, // Device is ready and able to accept commands
+    Busy,        // Device is executing a task or command
+    Unreachable, // Communication failed (e.g., heartbeat timeout)
+    Disabled     // Device manually or system-disabled
+};
+
+/**
+ * @enum OpState
+ * @brief Tracks the progress of discovery or operational commands.
+ *
+ * It is primarily used by DiscoverySession and OperationSession to manage
+ * workflows.
+ */
+enum class OpState
+{
+    Idle,               // No operation triggered
+    DiscoveryStarted,   // Initiated discovery sequence
+    DiscoveryRunning,   // Discovery commands in progress
+    DiscoveryCompleted, // Discovery finished successfully
+    WaitingForResponse, // mc is waiting for response
+    OperationQueued,    // Operational command is pending
+    OperationExecuting, // Currently running operational command
+    OperationCompleted, // Operational command finished successfully
+    OperationFailed,    // Error during command execution
+    Cancelled,          // Operation cancelled by host or timeout
+    TimedOut            // Operation exceeded expected duration
+};
+
+/**
+ * @enum DeviceCapabilitiesFlags
+ * @brief Flags representing device capabilities.
+ */
+enum class DeviceCapabilitiesFlags : uint8_t
+{
+    None = 0,
+    AtomicResourceRead = 1 << 0,
+    ExpandSupport = 1 << 1,
+    BejV1_1Support = 1 << 2
+};
+
+/**
+ * @struct DeviceCapabilities
+ * @brief Represents device capabilities using flags.
+ */
+struct DeviceCapabilities
+{
+    uint8_t value;
+
+    /**
+     * @brief Default constructor with pre-defined capability flags.
+     */
+    DeviceCapabilities() :
+        value(
+            static_cast<uint8_t>(DeviceCapabilitiesFlags::AtomicResourceRead) |
+            static_cast<uint8_t>(DeviceCapabilitiesFlags::BejV1_1Support))
+    {}
+
+    /**
+     * @brief Construct from raw uint8_t flags.
+     */
+    explicit DeviceCapabilities(uint8_t flags) : value(flags) {}
+
+    /**
+     * @brief Construct from bitfield8_t union.
+     */
+    explicit DeviceCapabilities(const bitfield8_t& bits) : value(bits.byte) {}
+
+    /**
+     * @brief Check if a specific capability flag is set.
+     */
+    constexpr bool has(DeviceCapabilitiesFlags flag) const
+    {
+        return (value & static_cast<uint8_t>(flag)) != 0;
+    }
+
+    /**
+     * @brief Return raw capability value.
+     */
+    uint8_t get() const
+    {
+        return value;
+    }
+
+    /**
+     * @brief Convert to bitfield8_t for interoperability.
+     */
+    bitfield8_t toBitfield() const
+    {
+        bitfield8_t bf{};
+        bf.byte = value;
+        return bf;
+    }
+};
+
+/**
+ * @enum FeatureBits
+ * @brief Bit flags representing supported features.
+ */
+enum FeatureBits : uint16_t
+{
+    HeadSupported = 1 << 0,
+    ReadSupported = 1 << 1,
+    CreateSupported = 1 << 2,
+    DeleteSupported = 1 << 3,
+    UpdateSupported = 1 << 4,
+    ReplaceSupported = 1 << 5,
+    ActionSupported = 1 << 6,
+    EventsSupported = 1 << 7,
+    BejV1_1Supported = 1 << 8
+};
+
+/**
+ * @struct FeatureSupport
+ * @brief Represents a set of supported features.
+ */
+struct FeatureSupport
+{
+    uint16_t value = 0;
+
+    FeatureSupport() = default;
+
+    // Constructor from bitfield16_t
+    explicit FeatureSupport(const bitfield16_t& bf) : value(bf.value) {}
+
+    explicit FeatureSupport(uint16_t v) : value(v) {}
+
+    constexpr bool has(FeatureBits bit) const
+    {
+        return (value & static_cast<uint16_t>(bit)) != 0;
+    }
+};
+
+using MetadataVariant = std::variant<std::string, uint8_t, uint16_t, uint32_t,
+                                     FeatureSupport, DeviceCapabilities>;
+
+/**
+ * @struct Metadata
+ * @brief Metadata information for a device.
+ */
+struct Metadata
+{
+    FeatureSupport mcFeatureSupport = FeatureSupport(
+        static_cast<uint16_t>(HeadSupported | ReadSupported | UpdateSupported));
+    FeatureSupport devFeatureSupport{};
+    uint8_t mcConcurrencySupport = 1;
+    uint8_t deviceConcurrencySupport = 0;
+    DeviceCapabilities devCapabilities{};
+    uint32_t devConfigSignature = 0;
+    std::string devProviderName;
+    uint32_t mcMaxTransferChunkSizeBytes = 64;
+    uint32_t devMaxTransferChunkSizeBytes = 0;
+    std::string etag;
+    std::string protocolVersion = "1.0";
+    std::string encoding = "application/json";
+    std::vector<std::string> supportedOperations;
+    uint32_t maxPayloadSize = 0;
+    std::string sessionId;
+
+    Metadata() = default;
+};
+
+} // namespace pldm::rde

--- a/rde/dictionary.cpp
+++ b/rde/dictionary.cpp
@@ -1,0 +1,107 @@
+#include "dictionary.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+namespace pldm::rde
+{
+Dictionary::Dictionary(uint32_t resourceId, uint8_t schemaClass,
+                       const std::string& deviceUUID,
+                       const std::string& basePath) :
+    resourceId(resourceId), schemaClass(schemaClass), deviceUUID(deviceUUID),
+    persistencePath(basePath)
+{}
+
+bool Dictionary::addToDictionaryBytes(std::span<const uint8_t> payload,
+                                      bool hasChecksum)
+{
+    if (hasChecksum && !payload.empty())
+    {
+        // Remove the last byte (checksum)
+        dictionary.insert(dictionary.end(), payload.begin(), payload.end() - 1);
+    }
+    else
+    {
+        dictionary.insert(dictionary.end(), payload.begin(), payload.end());
+    }
+    return true;
+}
+
+uint32_t Dictionary::getResourceId() const
+{
+    return resourceId;
+}
+
+uint8_t Dictionary::getSchemaClass() const
+{
+    return schemaClass;
+}
+
+std::span<const uint8_t> Dictionary::getDictionaryBytes() const
+{
+    return dictionary;
+}
+
+void Dictionary::markComplete()
+{
+    complete = true;
+}
+
+bool Dictionary::isComplete() const
+{
+    return complete;
+}
+
+void Dictionary::save() const
+{
+    std::ofstream outFile(persistencePath, std::ios::binary);
+    if (!outFile)
+        return;
+
+    outFile.write(reinterpret_cast<const char*>(&resourceId),
+                  sizeof(resourceId));
+    outFile.write(reinterpret_cast<const char*>(&schemaClass),
+                  sizeof(schemaClass));
+    outFile.write(reinterpret_cast<const char*>(&complete), sizeof(complete));
+
+    uint32_t size = dictionary.size();
+    outFile.write(reinterpret_cast<const char*>(&size), sizeof(size));
+    outFile.write(reinterpret_cast<const char*>(dictionary.data()), size);
+}
+
+void Dictionary::load()
+{
+    std::ifstream inFile(persistencePath, std::ios::binary);
+    if (!inFile)
+        return;
+
+    inFile.read(reinterpret_cast<char*>(&resourceId), sizeof(resourceId));
+    inFile.read(reinterpret_cast<char*>(&schemaClass), sizeof(schemaClass));
+    inFile.read(reinterpret_cast<char*>(&complete), sizeof(complete));
+
+    uint32_t size = 0;
+    inFile.read(reinterpret_cast<char*>(&size), sizeof(size));
+    dictionary.resize(size);
+    inFile.read(reinterpret_cast<char*>(dictionary.data()), size);
+}
+
+void Dictionary::reset()
+{
+    dictionary.clear();
+    complete = false;
+    std::filesystem::remove(persistencePath);
+}
+
+void Dictionary::loadFromFile(const std::string& filePath)
+{
+    std::ifstream file(filePath, std::ios::binary);
+    if (!file)
+    {
+        throw std::runtime_error("Failed to open dictionary file: " + filePath);
+    }
+
+    dictionary.assign(std::istreambuf_iterator<char>(file), {});
+    complete = true;
+}
+
+} // namespace pldm::rde

--- a/rde/dictionary.hpp
+++ b/rde/dictionary.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace pldm::rde
+{
+/**
+ * @class Dictionary
+ * @brief Represents a schema dictionary used in RDE for encoding and
+ * decoding payloads.
+ *
+ * The Dictionary class stores the raw dictionary bytes associated with a
+ * specific resource ID and schema class. It supports multipart accumulation
+ * of dictionary data and provides persistence across reboots using a
+ * device-specific UUID.
+ */
+class Dictionary
+{
+  public:
+    /**
+     * @brief Constructs a Dictionary with resource ID, schema class, and
+     * device UUID.
+     * @param[in] resourceId The resource ID associated with this dictionary.
+     * @param[in] schemaClass The schema class identifier.
+     * @param[in] deviceUUID A stable UUID used to scope persistence.
+     * @param[in] path Path to the device-specific file used
+     *            for persistent storage.
+     */
+    Dictionary(uint32_t resourceId, uint8_t schemaClass,
+               const std::string& deviceUUID, const std::string& path);
+
+    /**
+     * @brief Constructor.
+     */
+
+    Dictionary(const Dictionary&) = default;
+    Dictionary() = default;
+    Dictionary(Dictionary&&) = default;
+    Dictionary& operator=(const Dictionary&) = default;
+    Dictionary& operator=(Dictionary&&) = default;
+
+    /**
+     * @brief Destructor.
+     */
+    ~Dictionary() = default;
+
+    /**
+     * @brief Add a chunk of dictionary bytes to the internal buffer.
+     * @param[in] payload The payload chunk to append.
+     * @param[in] hasChecksum Indicates whether the payload includes a checksum.
+     * @return True if the chunk was added successfully.
+     */
+    bool addToDictionaryBytes(std::span<const uint8_t> payload,
+                              bool hasChecksum);
+
+    /**
+     * @brief Get the resource ID associated with this dictionary.
+     * @return The resource ID.
+     */
+    uint32_t getResourceId() const;
+
+    /**
+     * @brief Get the schema class associated with this dictionary.
+     * @return The schema class.
+     */
+    uint8_t getSchemaClass() const;
+
+    /**
+     * @brief Get a span over the accumulated dictionary bytes.
+     * @return A span of the dictionary byte buffer.
+     */
+    std::span<const uint8_t> getDictionaryBytes() const;
+
+    /**
+     * @brief Mark the dictionary as complete.
+     */
+    void markComplete();
+
+    /**
+     * @brief Check if the dictionary is complete.
+     * @return True if complete, false otherwise.
+     */
+    bool isComplete() const;
+
+    /**
+     * @brief Save the dictionary state to a persistent file.
+     */
+    void save() const;
+
+    /**
+     * @brief Load the dictionary state from a persistent file.
+     */
+    void load();
+
+    /**
+     * @brief Reset the dictionary state and remove the persistence file.
+     */
+    void reset();
+
+    /**
+     * @brief Retrieves the dictionary data.
+     *
+     * This function returns the complete dictionary as a vector of bytes.
+     * It can be used for serialization, inspection, or communication purposes.
+     *
+     * @return A vector containing the dictionary bytes.
+     */
+    std::vector<uint8_t> getDictionary() const;
+
+    /**
+     * @brief Load dictionary bytes from a binary file.
+     * @param filePath Path to the binary file.
+     * @throws std::runtime_error if file can't be read.
+     */
+    void loadFromFile(const std::string& filePath);
+
+  private:
+    /**
+     * @brief full path to the persistence file.
+     */
+    uint32_t resourceId = 0;
+    uint8_t schemaClass = 0;
+    std::string deviceUUID;
+    std::string persistencePath;
+    std::vector<uint8_t> dictionary;
+    bool complete = false;
+};
+
+} // namespace pldm::rde

--- a/rde/dictionary_manager.cpp
+++ b/rde/dictionary_manager.cpp
@@ -1,0 +1,150 @@
+#include "dictionary_manager.hpp"
+
+#include <phosphor-logging/lg2.hpp>
+
+extern "C"
+{
+#include "libpldm/rde.h"
+}
+#include <stdexcept>
+
+PHOSPHOR_LOG2_USING;
+
+namespace pldm::rde
+{
+
+DictionaryManager::DictionaryManager(std::string deviceUUID) :
+    deviceUUID(std::move(deviceUUID)),
+    dictRootPath(std::string(baseDictionaryRoot) + "/" + deviceUUID)
+{
+    std::filesystem::create_directories(dictRootPath);
+    buildAnnotationDictionary(dictRootPath / std::string(annotationFileName));
+    loadAllDictionariesFromRoot();
+}
+
+Dictionary& DictionaryManager::getOrCreate(uint32_t resourceId,
+                                           uint8_t schemaClass)
+{
+    DictionaryKey key{resourceId, schemaClass};
+    std::filesystem::path dictFilePath =
+        dictRootPath /
+        (std::string(dictFilePrefix) + std::to_string(resourceId) +
+         std::string(dictFileExtension));
+
+    auto [it, inserted] = dictionaries.emplace(
+        key, Dictionary(resourceId, schemaClass, deviceUUID, dictFilePath));
+    return it->second;
+}
+
+void DictionaryManager::addChunk(uint32_t resourceId, uint8_t schemaClass,
+                                 std::span<const uint8_t> payload,
+                                 bool hasChecksum, bool isFinalChunk)
+{
+    if (payload.empty())
+    {
+        throw std::invalid_argument("Payload chunk is empty.");
+    }
+
+    Dictionary& dict = getOrCreate(resourceId, schemaClass);
+
+    if (!dict.addToDictionaryBytes(payload, hasChecksum))
+    {
+        throw std::runtime_error("Failed to add chunk to dictionary.");
+    }
+
+    if (isFinalChunk)
+    {
+        dict.markComplete();
+        try
+        {
+            dict.save();
+        }
+        catch (const std::exception& e)
+        {
+            throw std::runtime_error(
+                std::string("Failed to persist dictionary: ") + e.what());
+        }
+    }
+}
+
+void DictionaryManager::reset(uint32_t resourceId, uint8_t schemaClass)
+{
+    DictionaryKey key{resourceId, schemaClass};
+    auto it = dictionaries.find(key);
+    if (it != dictionaries.end())
+    {
+        it->second.reset();
+        dictionaries.erase(it);
+    }
+}
+
+const Dictionary* DictionaryManager::get(uint32_t resourceId,
+                                         uint8_t schemaClass) const
+{
+    DictionaryKey key{resourceId, schemaClass};
+    auto it = dictionaries.find(key);
+    return (it != dictionaries.end()) ? &it->second : nullptr;
+}
+
+void DictionaryManager::buildAnnotationDictionary(const std::string& filePath)
+{
+    Dictionary dict(0, PLDM_RDE_SCHEMA_ANNOTATION, deviceUUID, filePath);
+    dict.loadFromFile(filePath);
+    dict.save();
+    annotationDictionary = std::move(dict);
+}
+
+const Dictionary* DictionaryManager::getAnnotationDictionary() const
+{
+    return annotationDictionary ? &(*annotationDictionary) : nullptr;
+}
+
+void DictionaryManager::loadAllDictionariesFromRoot()
+{
+    for (const auto& entry : std::filesystem::directory_iterator(dictRootPath))
+    {
+        if (!entry.is_regular_file())
+            continue;
+
+        const std::string filenameStr = entry.path().filename().string();
+        std::string_view filename = filenameStr;
+
+        if (filename.starts_with(dictFilePrefix) &&
+            filename.ends_with(dictFileExtension))
+        {
+            size_t start = dictFilePrefix.length();
+            size_t end = filename.length() - dictFileExtension.length();
+
+            // Extract core ID substring
+            std::string resourceIdStr =
+                std::string{filename.substr(start, end - start)};
+
+            if (resourceIdStr.empty())
+                continue;
+
+            try
+            {
+                uint32_t resourceId = std::stoul(resourceIdStr);
+                createDictionaryFromFile(resourceId, /*schemaClass=*/0,
+                                         entry.path().string());
+            }
+            catch (const std::exception& ex)
+            {
+                info(
+                    "DictionaryManager: Skipping file '{FILE}' — invalid resourceId: {ERROR}",
+                    "FILE", entry.path().filename().string(), "ERROR",
+                    ex.what());
+            }
+        }
+    }
+}
+
+void DictionaryManager::createDictionaryFromFile(
+    uint32_t resourceId, uint8_t schemaClass, const std::string& filePath)
+{
+    info("RDE: Loading Dictionary file '{NAME}'", "NAME", filePath);
+    Dictionary& dict = getOrCreate(resourceId, schemaClass);
+    dict.loadFromFile(filePath);
+    dict.save();
+}
+} // namespace pldm::rde

--- a/rde/dictionary_manager.hpp
+++ b/rde/dictionary_manager.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+#include "dictionary.hpp"
+
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <span>
+#include <string>
+#include <tuple>
+
+namespace pldm::rde
+{
+
+constexpr std::string_view baseDictionaryRoot = "/var/lib/pldm/dict";
+constexpr std::string_view dictFilePrefix = "dictionary_";
+constexpr std::string_view dictFileExtension = ".bin";
+constexpr std::string_view annotationFileName = "annotation.bin";
+
+/**
+ * @struct DictionaryKey
+ * @brief Uniquely identifies a dictionary instance by resource ID and schema
+ * class.
+ */
+struct DictionaryKey
+{
+    uint32_t resourceId;
+    uint8_t schemaClass;
+
+    bool operator<(const DictionaryKey& other) const
+    {
+        return std::tie(resourceId, schemaClass) <
+               std::tie(other.resourceId, other.schemaClass);
+    }
+};
+
+/**
+ * @class DictionaryManager
+ * @brief Manages multiple Dictionary instances for a single device across
+ * schema/resource combinations.
+ *
+ * This class provides functionality to create, retrieve, and manage Dictionary
+ * objects associated with specific Redfish resources and schema classes for a
+ * single RDE-capable device.
+ */
+class DictionaryManager
+{
+  public:
+    /**
+     * @brief Constructs a DictionaryManager for a specific device.
+     *
+     * Initializes the dictionary manager with a device UUID and ensures that
+     * the associated persistence directory exists on the filesystem.
+     *
+     * @param[in] deviceUUID Unique identifier string for the device whose
+     * dictionaries are managed by this instance.
+     */
+    explicit DictionaryManager(std::string deviceUUID);
+
+    DictionaryManager(const DictionaryManager&) = default;
+    DictionaryManager(DictionaryManager&&) = default;
+    DictionaryManager& operator=(const DictionaryManager&) = default;
+    DictionaryManager& operator=(DictionaryManager&&) = default;
+    ~DictionaryManager() = default;
+
+    /**
+     * @brief Get or create a dictionary instance.
+     * @param[in] resourceId The resource ID associated with the dictionary.
+     * @param[in] schemaClass The schema class identifier.
+     * @return Reference to the Dictionary instance.
+     */
+    Dictionary& getOrCreate(uint32_t resourceId, uint8_t schemaClass);
+
+    /**
+     * @brief Add a chunk of dictionary data to the appropriate Dictionary
+     * instance.
+     * @param[in] resourceId The resource ID.
+     * @param[in] schemaClass The schema class.
+     * @param[in] payload The dictionary data chunk.
+     * @param[in] hasChecksum Whether the payload includes a checksum byte.
+     * @param[in] isFinalChunk Whether this is the final chunk of the
+     * dictionary.
+     * @throws std::invalid_argument if the payload is invalid.
+     * @throws std::runtime_error if chunk processing or persistence fails.
+     */
+    void addChunk(uint32_t resourceId, uint8_t schemaClass,
+                  std::span<const uint8_t> payload, bool hasChecksum,
+                  bool isFinalChunk);
+
+    /**
+     * @brief Reset and remove a dictionary instance and its persistence file.
+     * @param[in] resourceId The resource ID.
+     * @param[in] schemaClass The schema class.
+     */
+    void reset(uint32_t resourceId, uint8_t schemaClass);
+
+    /**
+     * @brief Get a const pointer to a dictionary instance if it exists.
+     * @param[in] resourceId The resource ID.
+     * @param[in] schemaClass The schema class.
+     * @return Pointer to the Dictionary instance, or nullptr if not found.
+     */
+    const Dictionary* get(uint32_t resourceId, uint8_t schemaClass) const;
+
+    /**
+     * @brief Get the UUID of the device associated with this manager.
+     */
+    const std::string& getDeviceUUID() const
+    {
+        return deviceUUID;
+    }
+
+    /**
+     * @brief Build an annotation dictionary from a binary file.
+     * @param[in] filePath Path to the annotation dictionary binary file.
+     */
+    void buildAnnotationDictionary(const std::string& filePath);
+
+    /**
+     * @brief Get the annotation dictionary if it exists.
+     * @return Pointer to the annotation dictionary, or nullptr if not set.
+     */
+    const Dictionary* getAnnotationDictionary() const;
+
+    /**
+     * @brief Create a dictionary from a binary file and store it in the map.
+     * @param[in] resourceId Resource ID.
+     * @param[in] schemaClass Schema class.
+     * @param[in] filePath Path to the binary dictionary file.
+     */
+    void createDictionaryFromFile(uint32_t resourceId, uint8_t schemaClass,
+                                  const std::string& filePath);
+
+    /**
+     * @brief Loads all dictionary files from the root directory.
+     * Iterates through the dictionary root path extracts valid filenames,
+     * parses the resource ID, and delegates to createDictionaryFromFile().
+     */
+    void loadAllDictionariesFromRoot();
+
+  private:
+    std::string deviceUUID;
+    std::filesystem::path dictRootPath;
+    std::map<DictionaryKey, Dictionary> dictionaries;
+    std::optional<Dictionary> annotationDictionary;
+};
+
+} // namespace pldm::rde

--- a/rde/manager.hpp
+++ b/rde/manager.hpp
@@ -1,0 +1,284 @@
+#pragma once
+
+#include "requester/handler.hpp"
+#include "requester/mctp_endpoint_discovery.hpp"
+#include "xyz/openbmc_project/RDE/Manager/server.hpp"
+
+#include <libpldm/base.h>
+
+#include <common/instance_id.hpp>
+#include <common/types.hpp>
+#include <requester/handler.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+
+#include <future>
+#include <memory>
+#include <string>
+
+namespace pldm::rde
+{
+
+inline constexpr std::string_view RDEManagerObjectPath{
+    "/xyz/openbmc_project/RDE/Manager"};
+inline constexpr std::string_view DeviceObjectPath{
+    "/xyz/openbmc_project/RDE/Device"};
+
+using ObjectPath = sdbusplus::message::object_path;
+using OperationType =
+    sdbusplus::common::xyz::openbmc_project::rde::Common::OperationType;
+using PdrPayloadList = std::vector<std::vector<uint8_t>>;
+
+class Device; // Forward declaration
+
+/**
+ * @struct DeviceContext
+ * @brief Represents a Redfish Device Enablement (RDE)-capable device.
+ *
+ * This structure encapsulates all metadata and identifiers required to
+ * manage a device participating in PLDM for RDE over MCTP. It bridges
+ * internal PLDM stack representations and external D-Bus interfaces.
+ *
+ * ### Assumptions and Mapping:
+ * - `uuid`: Globally unique identifier used during internal registration.
+ * - `eid`: MCTP Endpoint ID, used internally in the PLDM stack.
+ * - `tid`: Terminus ID used in PLDM stack, represented as a byte.
+ * - `friendlyName`: Human-readable name for UI or logs.
+ * - `devicePtr`: Pointer to the actual device object.
+ */
+struct DeviceContext
+{
+    UUID uuid;                // Unique device UUID (internal registration)
+    eid deviceEID;            // MCTP Endpoint ID (internal PLDM stack)
+    pldm_tid_t tid;           // Terminus ID used in PLDM stack
+    std::string friendlyName; // Human-readable name for the device
+    std::shared_ptr<Device> devicePtr; // Pointer to associated device object
+};
+
+/**
+ * @class Manager
+ * @brief Core RDE Manager class implementing the D-Bus interface for Redfish
+ * Device Enablement.
+ *
+ * The Manager class is responsible for centralized management of the
+ * system. It exposes a D-Bus interface and coordinates various aspects of
+ * RDE-capable device handling and communication.
+ *
+ * Includes:
+ *   - Exposing the RDE control interface via D-Bus.
+ *   - Tracking discovered RDE-capable devices and their metadata (e.g., UUID,
+ *     EID).
+ *   - Managing the lifecycle of registered devices, including dynamic
+ *     add/remove operations.
+ *   - Forwarding Redfish-originated requests to appropriate downstream RDE
+ *     targets.
+ *   - Providing schema and resource discovery services to host tools or Redfish
+ *     clients.
+ *
+ * This class is implemented as a singleton service bound to a well-known name
+ * on the system bus.
+ */
+class Manager :
+    public sdbusplus::server::object::object<
+        sdbusplus::xyz::openbmc_project::RDE::server::Manager>,
+    public pldm::MctpDiscoveryHandlerIntf
+{
+  public:
+    Manager(const Manager&) = delete;
+    Manager& operator=(const Manager&) = delete;
+    Manager(Manager&&) = delete;
+    Manager& operator=(Manager&&) = delete;
+
+    ~Manager() = default;
+
+    /**
+     * @brief Construct an RDE Manager object.
+     *
+     * Initializes the RDE Manager interface on the specified D-Bus path,
+     * enabling support for Redfish Device Enablement operations.
+     *
+     * @param[in] bus           Reference to the system D-Bus connection.
+     * @param[in] instanceIdDb  Pointer to the instance ID database used for
+     *                          PLDM message tracking.
+     * @param[in] handler       Pointer to the PLDM request handler for sending
+     *                          and receiving messages.
+     */
+    Manager(sdbusplus::bus::bus& bus, pldm::InstanceIdDb* instanceIdDb,
+            pldm::requester::Handler<pldm::requester::Request>* handler);
+
+    /**
+     * @brief Get the instance ID database pointer.
+     *
+     * @return Pointer to the instance ID database.
+     */
+    inline pldm::InstanceIdDb* getInstanceIdDb() const
+    {
+        return instanceIdDb_;
+    }
+
+    /**
+     * @brief Get the PLDM request handler pointer.
+     *
+     * @return Pointer to the PLDM request handler.
+     */
+    inline pldm::requester::Handler<pldm::requester::Request>* getHandler()
+        const
+    {
+        return handler_;
+    }
+
+    /**
+     * @brief Get the D-Bus connection reference.
+     *
+     * @return Reference to the D-Bus connection.
+     */
+    inline sdbusplus::bus::bus& getBus()
+    {
+        return bus_;
+    }
+
+    /**
+     * @brief Retrieves a pointer to the DeviceContext by eid.
+     * @param deviceEID[in] MCTP Endpoint ID
+     * @return Pointer to DeviceContext or nullptr if not found
+     */
+    DeviceContext* getDeviceContext(eid deviceEID);
+
+    /**
+     * @brief Implementation for StartRedfishOperation
+     * Begin execution of a Redfish operation on the target device. Returns a
+     * D-Bus object path for tracking asynchronous progress through an
+     * OperationTask instance.
+     *
+     * @param[in] operationID - Unique identifier for this operation lifecycle.
+     *            This ID must be supplied by the caller and reused for any
+     *            related commands (e.g., cancellation, polling). Enables
+     *            multi-phase tracking and client-side logical correlation.
+     * @param[in] operationType - Type of Redfish operation to perform.
+     * @param[in] targetURI - URI of the target Redfish resource or action.
+     * @param[in] deviceUUID - Uniquely identifies the target device instance.
+     * @param[in] eid - Optional endpoint identifier for MCTP or similar
+     *            transport. Omit for protocols that do not use EID or when
+     *            resolved internally.
+     * @param[in] payload - Redfish payload content, either embedded inline as
+     *            a JSON/BEJ string, or provided as an external file path
+     *            reference.
+     * @param[in] payloadFormat - Specifies whether the payload is embedded
+     *            inline or referenced via external file path.
+     * @param[in] encodingFormat - Encoding format of the payload. Choose
+     * 'JSON' for plain text or 'BEJ' for compact binary. JSON is the default
+     * for broader compatibility.
+     * @param[in] sessionId - Optional grouping label used to associate
+     * multiple operations under a logical client session. Useful for
+     * long-running tasks, audit logging, or correlation across coordinated
+     * workflows.
+     *
+     * @return path[sdbusplus::message::object_path] - D-Bus object path for
+     *         the xyz.openbmc_project.RDE.OperationTask created for this
+     *         operation. This object allows clients to monitor execution
+     *         progress, retrieve response metadata, and manage task lifecycle.
+     */
+    ObjectPath startRedfishOperation(
+        uint32_t operationID,
+        sdbusplus::common::xyz::openbmc_project::rde::Common::OperationType
+            operationType,
+        std::string targetURI, std::string deviceUUID, uint8_t eid,
+        std::string payload, PayloadFormatType payloadFormat,
+        EncodingFormatType encodingFormat, std::string sessionId) override;
+
+    /** @brief Implementation for GetSupportedOperations
+     *  Report the list of supported Redfish operations for a specified target
+     * device.
+     *
+     *  @param[in] deviceUUID - Uniquely identifies the target device.
+     *
+     *  @return
+     * supportedOps[std::vector<sdbusplus::common::xyz::openbmc_project::rde::Common::OperationType>]
+     * - Operations supported by the device, determined via capability
+     * discovery.
+     */
+    std::vector<OperationType> getSupportedOperations(
+        std::string deviceUUID) override;
+
+    /** @brief Implementation for GetDeviceSchemaInfo
+     *  Retrieve the schema metadata for a specific target device as exposed via
+     * SchemaResources. This includes Redfish-compatible URI fragments, schema
+     * types, and supported operations.
+     *
+     *  @param[in] deviceUUID - Uniquely identifies the target device.
+     *
+     *  @return schemaInfo[std::map<std::string, std::map<std::string,
+     * std::variant<int64_t, std::string>>>] - Dictionary of schema metadata
+     * indexed by resource ID, aligned with the SchemaResourceKeys definition.
+     */
+    std::map<std::string,
+             std::map<std::string, std::variant<int64_t, std::string>>>
+        getDeviceSchemaInfo(std::string deviceUUID) override;
+
+    /** @brief Helper function to invoke registered handlers for
+     *         the added MCTP endpoints
+     *
+     *  @param[in] mctpInfos - information of discovered MCTP endpoints
+     */
+    void handleMctpEndpoints(const MctpInfos& mctpInfos) override;
+
+    /** @brief Helper function to invoke registered handlers for
+     *         the removed MCTP endpoints
+     *
+     *  @param[in] mctpInfos - information of removed MCTP endpoints
+     */
+    void handleRemovedMctpEndpoints(const MctpInfos&) override
+    {
+        return;
+    }
+
+    /** @brief Helper function to invoke registered handlers for
+     *  updating the availability status of the MCTP endpoint
+     *
+     *  @param[in] mctpInfo - information of the target endpoint
+     *  @param[in] availability - new availability status
+     */
+    void updateMctpEndpointAvailability(const MctpInfo&, Availability) override
+    {
+        return;
+    }
+
+    /** @brief Get Active EIDs.
+     *
+     *  @param[in] addr - MCTP address of terminus
+     *  @param[in] terminiNames - MCTP terminus name
+     */
+    std::optional<mctp_eid_t> getActiveEidByName(const std::string&) override
+    {
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Create a device D-Bus object associated with PLDM discovery.
+     *
+     * This method initializes and registers a D-Bus object representing a
+     * discovered device, using its endpoint ID (EID), unique identifier (UUID),
+     * and type identifier (TID). It is typically invoked during the PLDM
+     * discovery session as part of Redfish Device Enablement.
+     *
+     * @param deviceEID[in]   Endpoint ID of the device as reported during MCTP
+     * discovery.
+     * @param devUUID[in]  Unique identifier string for the device.
+     * @param tid[in]   Type ID of the device (PLDM Terminus ID).
+     * @param pdrPayloads[in] Vector of raw Redfish Resource PDR payloads,
+     *        each PDR as a vector of bytes (std::vector<uint8_t>)
+     */
+    void createDeviceDbusObject(eid deviceEID, const UUID& devUUID,
+                                pldm_tid_t tid,
+                                const PdrPayloadList& pdrPayloads);
+
+  private:
+    pldm::InstanceIdDb* instanceIdDb_ = nullptr;
+    pldm::requester::Handler<pldm::requester::Request>* handler_ = nullptr;
+    sdbusplus::bus::bus& bus_;
+    std::unordered_map<eid, DeviceContext> eidMap_;
+    std::unordered_map<eid, std::unique_ptr<sdbusplus::bus::match_t>>
+        signalMatches_;
+};
+
+} // namespace pldm::rde

--- a/rde/manager.hpp
+++ b/rde/manager.hpp
@@ -23,6 +23,7 @@ inline constexpr std::string_view RDEManagerObjectPath{
     "/xyz/openbmc_project/RDE/Manager"};
 inline constexpr std::string_view DeviceObjectPath{
     "/xyz/openbmc_project/RDE/Device"};
+inline constexpr std::string_view DeviceServiceName{"xyz.openbmc_project.RDE"};
 
 using ObjectPath = sdbusplus::message::object_path;
 using OperationType =

--- a/rde/resource_registry.cpp
+++ b/rde/resource_registry.cpp
@@ -1,0 +1,356 @@
+#include "resource_registry.hpp"
+
+#include <libpldm/platform.h>
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <stdexcept>
+
+namespace pldm::rde
+{
+
+ResourceRegistry::ResourceRegistry(uint16_t eid, void* parent) :
+    entityId_(eid), parent_(parent)
+{}
+
+void ResourceRegistry::registerResource(const std::string& resourceId,
+                                        const ResourceInfo& info)
+{
+    resourceMap_[resourceId] = info;
+    uriToResourceId_[info.uri] = resourceId;
+    resourceIdToUri_[resourceId] = info.uri;
+    classToUri_[info.schemaClass] = info.uri;
+}
+
+const ResourceInfo& ResourceRegistry::getByUri(const std::string& uri) const
+{
+    auto it = resourceMap_.find(uri);
+    if (it == resourceMap_.end())
+    {
+        throw std::out_of_range("URI not found in resourceMap");
+    }
+    return it->second;
+}
+
+const ResourceInfo& ResourceRegistry::getBySchemaClass(
+    uint16_t schemaClass) const
+{
+    auto it = classToUri_.find(schemaClass);
+    if (it == classToUri_.end())
+    {
+        throw std::out_of_range("Schema class not found");
+    }
+    return getByUri(it->second);
+}
+
+const std::string& ResourceRegistry::getResourceIdFromUri(
+    const std::string& uri) const
+{
+    auto it = uriToResourceId_.find(uri);
+    if (it == uriToResourceId_.end())
+    {
+        throw std::out_of_range("URI not found in uriToResourceId");
+    }
+    return it->second;
+}
+
+const std::string& ResourceRegistry::getUriFromResourceId(
+    const std::string& resourceId) const
+{
+    auto it = resourceIdToUri_.find(resourceId);
+    if (it == resourceIdToUri_.end())
+    {
+        throw std::out_of_range("Resource ID not found in resourceIdToUri");
+    }
+    return it->second;
+}
+void ResourceRegistry::getDeviceSchemaInfo(
+    std::vector<std::unordered_map<std::string, std::string>>& out) const
+{
+    for (const auto& [resourceId, info] : resourceMap_)
+    {
+        for (const auto& op : info.operations)
+        {
+            std::string opStr;
+            switch (op)
+            {
+                case OperationType::HEAD:
+                    opStr = "HEAD";
+                    break;
+                case OperationType::READ:
+                    opStr = "READ";
+                    break;
+                case OperationType::CREATE:
+                    opStr = "CREATE";
+                    break;
+                case OperationType::DELETE:
+                    opStr = "DELETE";
+                    break;
+                case OperationType::UPDATE:
+                    opStr = "UPDATE";
+                    break;
+                case OperationType::REPLACE:
+                    opStr = "REPLACE";
+                    break;
+                case OperationType::ACTION:
+                    opStr = "ACTION";
+                    break;
+                default:
+                    opStr = "UNKNOWN";
+                    break;
+            }
+
+            std::unordered_map<std::string, std::string> entry;
+
+            entry["uri"] = info.uri;
+            entry["schemaName"] = info.schemaName;
+            entry["schemaVersion"] = info.schemaVersion;
+            entry["schemaClass"] = std::to_string(info.schemaClass);
+            entry["ProposedContainingResourceName"] =
+                info.propContainResourceName;
+            entry["operation"] = opStr;
+
+            out.push_back(std::move(entry));
+        }
+    }
+}
+
+void ResourceRegistry::reset()
+{
+    resourceMap_.clear();
+    uriToResourceId_.clear();
+    resourceIdToUri_.clear();
+    classToUri_.clear();
+}
+
+void ResourceRegistry::saveToFile(const std::string& path) const
+{
+    nlohmann::json j;
+    for (const auto& [resourceId, info] : resourceMap_)
+    {
+        j.push_back(
+            {{"subURI", info.uri},
+             {"schemaClass", info.schemaClass},
+             {"schemaName", info.schemaName},
+             {"schemaVersion", info.schemaVersion},
+             {"ProposedContainingResourceName", info.propContainResourceName},
+             {"operations", info.operations},
+             {"resourceId", resourceId}});
+    }
+
+    std::ofstream file(path);
+    if (!file)
+    {
+        throw std::runtime_error("Failed to open file for writing: " + path);
+    }
+
+    file << j.dump(4);
+}
+
+void ResourceRegistry::loadFromFile(const std::string& path)
+{
+    std::ifstream file(path);
+    if (!file)
+    {
+        throw std::runtime_error("Failed to open file for reading: " + path);
+    }
+
+    nlohmann::json j;
+    file >> j;
+
+    reset(); // Clear any previously registered resources
+
+    for (const auto& entry : j)
+    {
+        ResourceInfo info;
+        info.uri = entry.at("subURI").get<std::string>();
+        info.schemaClass = entry.at("schemaClass").get<pldm_rde_schema_type>();
+        info.schemaName = entry.at("schemaName").get<std::string>();
+        info.schemaVersion = entry.at("schemaVersion").get<std::string>();
+        info.propContainResourceName =
+            entry.at("ProposedContainingResourceName").get<std::string>();
+        info.operations =
+            entry.at("operations").get<std::vector<OperationType>>();
+        std::string resourceId = entry.at("resourceId").get<std::string>();
+
+        registerResource(resourceId, info);
+    }
+}
+
+std::string ResourceRegistry::getRdeResourceName(uint8_t* ptr, size_t length)
+{
+    if (ptr == nullptr || length == 0)
+    {
+        return {};
+    }
+
+    // Remove trailing null character if present
+    if (ptr[length - 1] == '\0')
+    {
+        --length;
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return std::string(reinterpret_cast<const char*>(ptr), length);
+}
+
+std::string ResourceRegistry::constructFullUriRecursive(
+    uint16_t resourceId,
+    const std::unordered_map<uint16_t, std::string>& subUriMap,
+    const std::unordered_map<uint16_t, uint16_t>& parentMap)
+{
+    if (resourceId == 0 || subUriMap.find(resourceId) == subUriMap.end())
+        return "";
+
+    uint16_t parentId =
+        parentMap.count(resourceId) ? parentMap.at(resourceId) : 0;
+    std::string parentUri =
+        constructFullUriRecursive(parentId, subUriMap, parentMap);
+    std::string part = subUriMap.at(resourceId);
+
+    if (!part.empty() && part.front() != '/')
+        parentUri += "/";
+    parentUri += part;
+
+    /*
+    TODO revisit this during bringup
+    // Warning if subURI is '0' or empty
+    if (part == "0" || part.empty()) {
+        // Warning: suspicious subURI detected
+        // Consider verifying if this is intentional
+    }
+
+    // Avoid duplicate segments like '/0/0/Settings'
+    if (parentUri.size() >= part.size() + 1 &&
+        parentUri.substr(parentUri.size() - part.size() - 1) == "/" + part)
+    { return parentUri;
+    }
+    */
+
+    return parentUri;
+}
+
+std::string ResourceRegistry::getMajorSchemaVersion(ver32_t& version)
+{
+    constexpr int MaxSize = 1024;
+    char version_buffer[MaxSize] = {0};
+    int rc = 0;
+
+    if (version.alpha == 0xFF && version.update == 0xFF &&
+        version.minor == 0xFF && version.major == 0xFF)
+    {
+        return std::string("?.?");
+    }
+    else
+    {
+        rc = ver2str(&version, version_buffer, sizeof(version_buffer));
+        if (rc <= 0)
+            return "?.?";
+    }
+    return std::string(version_buffer, rc);
+}
+
+std::vector<ResourceInfo> ResourceRegistry::parseRedfishResourcePDRs(
+    const std::vector<std::shared_ptr<pldm_redfish_resource_pdr>>& pdrList)
+{
+    std::unordered_map<uint16_t, std::string> subUriMap;
+    std::unordered_map<uint16_t, uint16_t> parentMap;
+    std::unordered_map<uint16_t, ResourceInfo> resInfoMap;
+    std::vector<ResourceInfo> resInfoVect;
+
+    for (const auto& pdr : pdrList)
+    {
+        uint16_t rid = static_cast<uint16_t>(pdr->resource_id);
+        uint16_t parent = static_cast<uint16_t>(pdr->cont_resrc_id);
+        bool isRoot = (pdr->cont_resrc_id == 0);
+        std::string proposedRoot = getRdeResourceName(
+            pdr->prop_cont_resrc_name, pdr->prop_cont_resrc_length);
+
+        if (isRoot && !proposedRoot.empty())
+            subUriMap[rid] = proposedRoot;
+        else
+            subUriMap[rid] =
+                getRdeResourceName(pdr->sub_uri_name, pdr->sub_uri_length);
+        parentMap[rid] = parent;
+
+        for (size_t i = 0; i < pdr->add_resrc_id_count; ++i)
+        {
+            add_resrc_t* add = pdr->additional_resrc[i];
+            uint16_t addId = static_cast<uint16_t>(add->resrc_id);
+            subUriMap[addId] = getRdeResourceName(add->name, add->length);
+            parentMap[addId] = rid;
+        }
+
+        ResourceInfo info;
+        info.resourceId = std::to_string(rid);
+        info.schemaName = getRdeResourceName(pdr->major_schema.name,
+                                             pdr->major_schema.length);
+        info.schemaVersion = getMajorSchemaVersion(pdr->major_schema_version);
+        info.schemaClass = PLDM_RDE_SCHEMA_MAJOR;
+        info.propContainResourceName = proposedRoot;
+        resInfoMap[rid] = info;
+    }
+
+    for (const auto& [rid, _] : subUriMap)
+    {
+        ResourceInfo info =
+            resInfoMap.count(rid) ? resInfoMap[rid] : ResourceInfo{};
+        info.resourceId = std::to_string(rid);
+        info.uri = constructFullUriRecursive(rid, subUriMap, parentMap);
+        resInfoVect.push_back(info);
+    }
+
+    return resInfoVect;
+}
+
+void ResourceRegistry::loadFromResourcePDR(
+    const std::vector<std::vector<uint8_t>>& payloads)
+{
+    // Clear registry before loading new data
+    reset();
+
+    std::vector<std::shared_ptr<pldm_redfish_resource_pdr>> pdrList;
+
+    for (const auto& data : payloads)
+    {
+        if (data.empty())
+        {
+            continue; // Skip empty payloads
+        }
+
+        const uint8_t* ptr = data.data();
+        auto parsedPdr = std::make_shared<pldm_redfish_resource_pdr>();
+        auto rc =
+            decode_redfish_resource_pdr_data(ptr, data.size(), parsedPdr.get());
+
+        if (rc != 0 || !parsedPdr)
+        {
+            throw std::runtime_error(
+                "Failed to decode one of the Redfish Resource PDRs");
+        }
+
+        pdrList.push_back(parsedPdr);
+    }
+
+    std::vector<ResourceInfo> resourceInfos;
+    try
+    {
+        resourceInfos = parseRedfishResourcePDRs(pdrList);
+    }
+    catch (const std::exception& e)
+    {
+        throw std::runtime_error(
+            std::string("Failed to parse resource info: ") + e.what());
+    }
+
+    for (const auto& info : resourceInfos)
+    {
+        const std::string& resourceId = info.resourceId;
+        registerResource(resourceId, info);
+    }
+
+    // Need to replace with unique file name
+    saveToFile("/tmp/ResourceRegistry.txt");
+}
+
+} // namespace pldm::rde

--- a/rde/resource_registry.hpp
+++ b/rde/resource_registry.hpp
@@ -1,0 +1,264 @@
+#pragma once
+
+#include "xyz/openbmc_project/RDE/Common/common.hpp"
+
+#include <libpldm/platform.h>
+
+extern "C"
+{
+#include "libpldm/rde.h"
+}
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @file ResourceRegistry.hpp
+ * @brief Provides per-device resource and schema metadata management for RDE.
+ */
+
+namespace pldm::rde
+{
+
+using OperationType =
+    sdbusplus::common::xyz::openbmc_project::rde::Common::OperationType;
+
+struct ResourceInfo
+{
+    std::string resourceId;           // Resource ID used for dictionary lookup
+    std::string uri;                  // subURI from RDE device
+    pldm_rde_schema_type schemaClass; // Schema class identifier (RDE)
+    std::string schemaName;           // Schema name (e.g., "Chassis")
+    std::string schemaVersion;        // Schema version (e.g., "1.2.0")
+    std::string propContainResourceName;
+    std::vector<OperationType> operations; // Supported RDE operations
+};
+
+/**
+ * @class ResourceRegistry
+ * @brief Manages schema and resource metadata for a specific RDE-capable
+ * device.
+ */
+class ResourceRegistry
+{
+  public:
+    // Special member functions
+    ResourceRegistry() = default;
+    ~ResourceRegistry() = default;
+    ResourceRegistry(const ResourceRegistry&) = default;
+    ResourceRegistry(ResourceRegistry&&) noexcept = default;
+    ResourceRegistry& operator=(const ResourceRegistry&) = default;
+    ResourceRegistry& operator=(ResourceRegistry&&) noexcept = default;
+
+    /**
+     * @brief Construct a ResourceRegistry for a specific entity.
+     * @param[in] eid Entity ID identifying the device.
+     * @param[in] parent Pointer to parent object for hierarchical access.
+     */
+    explicit ResourceRegistry(uint16_t eid, void* parent = nullptr);
+
+    /**
+     * @brief Register a resource and its schema metadata.
+     * @param[in] resourceId The resource ID (e.g., "Chassis_1")
+     * @param[in] info The metadata associated with the resource.
+     */
+    void registerResource(const std::string& resourceId,
+                          const ResourceInfo& info);
+
+    /**
+     * @brief Retrieve resource metadata by resource ID.
+     * @param[in] resourceId The resource ID to look up.
+     * @return Reference to ResourceInfo or throws std::out_of_range if not
+     * found.
+     */
+    const ResourceInfo& getByResourceId(const std::string& resourceId) const;
+
+    /**
+     * @brief Retrieve resource metadata by schema class.
+     * @param[in] schemaClass The schema class identifier.
+     * @return Reference to ResourceInfo or throws std::out_of_range if not
+     * found.
+     */
+    const ResourceInfo& getBySchemaClass(uint16_t schemaClass) const;
+
+    /**
+     * @brief Retrieve resource metadata by URI.
+     * @param[in] uri The Redfish URI.
+     * @return Reference to ResourceInfo or throws std::out_of_range if not
+     * found.
+     */
+    const ResourceInfo& getByUri(const std::string& uri) const;
+
+    /**
+     * @brief Get the resource ID associated with a given URI.
+     * @param[in] uri The Redfish URI.
+     * @return The corresponding resource ID.
+     */
+    const std::string& getResourceIdFromUri(const std::string& uri) const;
+
+    /**
+     * @brief Get the URI associated with a given resource ID.
+     * @param[in] resourceId The resource ID.
+     * @return The corresponding URI.
+     */
+    const std::string& getUriFromResourceId(
+        const std::string& resourceId) const;
+
+    /**
+     * @brief Retrieve all schema information for the device.
+     * @param[out] Reference to vector to populate with schema descriptors.
+     */
+    void getDeviceSchemaInfo(
+        std::vector<std::unordered_map<std::string, std::string>>& out) const;
+
+    /**
+     * @brief Clear all registered resource metadata.
+     */
+    void reset();
+
+    /**
+     * @brief Save the registry to a file.
+     * @param path[in] File path to save the registry.
+     */
+    void saveToFile(const std::string& path) const;
+
+    /**
+     * @brief Load the registry from a file.
+     * @param path File path to load the registry.
+     */
+    void loadFromFile(const std::string& path);
+
+    /**
+     * @brief Load and parse Redfish Resource PDRs from multiple payloads.
+     *
+     * This function processes a batch of encoded Redfish Resource PDR payloads,
+     * decoding each one into a `pldm_redfish_resource_pdr` structure.
+     * Successfully decoded PDRs are stored and parsed to extract resource
+     * information.
+     *
+     * Parsed resources are registered into the internal registry for later
+     * lookup. The registry is reset before loading new data.
+     *
+     * @param[in] payloads A list of encoded PDR byte buffers, where each entry
+     * represents a single Redfish Resource PDR payload.
+     *
+     * @throws std::runtime_error if decoding or parsing fails for any valid
+     * payload.
+     */
+    void loadFromResourcePDR(const std::vector<std::vector<uint8_t>>& payloads);
+
+    /**
+     * @brief Get the current map of resource metadata entries.
+     *
+     * Each entry is keyed by resource ID and contains schema metadata
+     * such as URI, schema name, version, operations, and classification.
+     *
+     * @return Reference to the internal resource map.
+     */
+    const std::unordered_map<std::string, ResourceInfo>& getResourceMap() const
+    {
+        return resourceMap_;
+    }
+
+    /**
+     * @brief Convert numeric resource ID to string.
+     *
+     * Simple wrapper around `std::to_string` to enable uniform usage.
+     *
+     * @param[in] id Numeric resource ID.
+     * @return String representation of the resource ID.
+     */
+    inline std::string toRawResourceIdString(uint32_t id)
+    {
+        return std::to_string(id);
+    }
+
+    /**
+     * @brief Convert string representation to numeric resource ID.
+     *
+     * Parses raw numeric strings into `uint32_t`. Assumes well-formed input.
+     *
+     * @param[in] idStr Resource ID as string.
+     * @return Parsed numeric resource ID.
+     * @throws std::invalid_argument or std::out_of_range on bad input.
+     */
+    inline uint32_t fromRawResourceIdString(const std::string& idStr)
+    {
+        return static_cast<uint32_t>(std::stoul(idStr));
+    }
+
+  private:
+    /**
+     * @brief Construct the full Redfish URI for a given resource.
+     *
+     * This function recursively builds the URI of a resource by combining the
+     * base URI, sub-URIs, and parent relationships as defined in Redfish
+     * resource hierarchy.
+     *
+     * It looks up the provided resourceId in subUriMap to append its relative
+     * URI segment. If the resource has a parent in the parentMap, the parent's
+     * URI is prepended as needed to form a full hierarchical path.
+     *
+     * @param[in] resourceId The unique identifier of the resource.
+     * @param[in] subUriMap A map of resourceId to its relative URI component.
+     * @param[in] parentMap A map of resourceId to its parent resourceId.
+     *
+     * @return A string representing the fully constructed Redfish URI.
+     */
+    std::string constructFullUriRecursive(
+        uint16_t resourceId,
+        const std::unordered_map<uint16_t, std::string>& subUriMap,
+        const std::unordered_map<uint16_t, uint16_t>& parentMap);
+
+    /** @brief Extract the schema version.
+     *
+     *  This function parses the 32-bit PLDM version structure (ver32_t) and
+     *  extracts the version component, returning it as a string.
+     *
+     *  @param[in] version - The 32-bit encoded PLDM version (ver32_t).
+     *
+     *  @return A string representing the version number.
+     */
+    std::string getMajorSchemaVersion(ver32_t& version);
+
+    /** @brief Extract the RDE resource name from a raw byte buffer.
+     *
+     *  @param[in] ptr - Pointer to the raw byte buffer containing the resource
+     * name.
+     *  @param[in] length - Length of the byte buffer.
+     *
+     *  @return A string representing the decoded RDE resource name.
+     */
+
+    std::string getRdeResourceName(uint8_t* ptr, size_t length);
+
+    /** @brief Parse a list of Redfish Resource PDRs into structured resource
+     *        information.This function processes a vector of shared pointers
+     *        to PLDM Redfish Resource   PDR structures and extracts relevant
+     *        information from each entry to populate   a list of `ResourceInfo
+     *        objects.
+     *
+     *  @param[in] pdrList - A vector of shared pointers to PLDM Redfish
+     *             Resource PDRs.
+     *
+     *  @return A vector of `ResourceInfo` structures containing parsed data
+     *          from the PDRs.
+     */
+    std::vector<ResourceInfo> parseRedfishResourcePDRs(
+        const std::vector<std::shared_ptr<pldm_redfish_resource_pdr>>& pdrList);
+
+    uint16_t entityId_;   // Entity ID of the associated device
+    void* parent_;        // Pointer to parent object for context
+    std::unordered_map<std::string, ResourceInfo>
+        resourceMap_;     // Map from resource ID to metadata
+    std::unordered_map<std::string, std::string>
+        uriToResourceId_; // URI to resource ID map
+    std::unordered_map<std::string, std::string>
+        resourceIdToUri_; // Resource ID to URI map
+    std::unordered_map<uint16_t, std::string>
+        classToUri_;      // Schema class to URI map
+};
+
+} // namespace pldm::rde


### PR DESCRIPTION
The initial framework for Redfish Device Enablement (RDE) with the following major components:

RDE Manager class: Tracks device context, manages lifecycle state, and facilitates dynamic updates from PLDM command responses.
Device base class support: Adds foundational hooks and member interfaces to the Device class, allowing metadata management and refresh operations for Redfish-compliant devices.
DiscoverySession class: Handles Redfish device negotiation and discovery workflows via PLDM, including issuing and parsing NegotiateRedfishParameters responses.
RDE Manager integration in pldmd: Introduces a centralized manager responsible for coordinating RDE device registration, session handling, and discovery scheduling.
D-Bus DiscoveryComplete signal: Implements support to broadcast a structured PLDM DiscoveryComplete signal over D-Bus once Redfish discovery is complete
The NegotiateRedfishParameters PLDM command was tested and successfully verified as part of this update.