### PR TITLE
rde: Use system-installed annotation dictionary

### DIFF
--- a/rde/dictionary_manager.cpp
+++ b/rde/dictionary_manager.cpp
@@ -18,7 +18,13 @@ DictionaryManager::DictionaryManager(std::string uuid) :
     dictRootPath(std::string(baseDictionaryRoot) + "/" + deviceUUID)
 {
     std::filesystem::create_directories(dictRootPath);
-    buildAnnotationDictionary(dictRootPath / std::string(annotationFileName));
+    // TODO: Revisit this path once host-based annotation file support
+    // is implemented.
+    // buildAnnotationDictionary(dictRootPath /
+    // std::string(annotationFileName));
+    constexpr const char* annotationPath =
+        "/usr/share/redfish-schema-pack/dictionaries/annotation.bin";
+    buildAnnotationDictionary(annotationPath);
 
     const std::string triggerFile = "/tmp/.enable_dict_bootstrap";
     if (std::filesystem::exists(triggerFile))


### PR DESCRIPTION
Update `DictionaryManager` to use the standard system-installed annotation dictionary located at
 `/usr/share/redfish-schema-pack/dictionaries/annotation.bin`,
which is provided by the `annotation-dictionary` recipe and sourced from the DMTF Redfish-Publications repository.

This change replaces the previous logic that constructed the dictionary path from `dictRootPath`, and instead leverages the canonical DMTF version of the annotation file. This helps improve RDE discovery performance and ensures consistency with the published Redfish schema.

The original path logic is retained as a TODO for future revisitation once host-based annotation file support is fully integrated.