### PR TITLE
RDE: Improve error handling and code cleanup for RDE code base

### DIFF
--- a/rde/device.cpp
+++ b/rde/device.cpp
@@ -61,16 +61,19 @@ void Device::refreshDeviceInfo()
             "EID", static_cast<int>(eid()), "COUNT", self.use_count());
 
         discovSession_ = std::make_unique<DiscoverySession>(self);
+        this->negotiationStatus(NegotiationStatus::InProgress);
         discovSession_->doNegotiateRedfish();
     }
     catch (const sdbusplus::exception::SdBusError& e)
     {
         error("refreshDeviceInfo D-Bus error: Msg={MSG}", "MSG", e.what());
+        this->negotiationStatus(NegotiationStatus::Failed);
         return;
     }
     catch (const std::exception& e)
     {
         error("refreshDeviceInfo: Failed : Msg={MSG}", "MSG", e.what());
+        this->negotiationStatus(NegotiationStatus::Failed);
         return;
     }
 

--- a/rde/device.cpp
+++ b/rde/device.cpp
@@ -27,7 +27,8 @@ Device::Device(sdbusplus::bus::bus& bus, sdeventplus::Event& event,
 
 Device::~Device()
 {
-    info("RDE: D-Bus Device object destroyed");
+    info("RDE : D-Bus Device object destroyed UUID:{UUID} EID:{EID}", "UUID",
+         deviceUUID(), "EID", static_cast<int>(eid()));
 }
 
 void Device::refreshDeviceInfo()

--- a/rde/discov_session.cpp
+++ b/rde/discov_session.cpp
@@ -151,6 +151,7 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
         error("RDE: Null PLDM response received from endpoint ID {EID}", "EID",
               eid_);
         updateState(OpState::OperationFailed);
+        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
         return;
     }
 
@@ -159,6 +160,7 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
         error("RDE:rxLen is 0; applying fallback length. EID={EID}", "EID",
               eid_);
         updateState(OpState::OperationFailed);
+        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
         return;
     }
 
@@ -179,6 +181,7 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
             "RDE: Failed to decode NegotiateRedfishParameters response rc:{RC} cc:{CC}",
             "RC", rc, "CC", cc);
         updateState(OpState::OperationFailed);
+        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
         return;
     }
 
@@ -269,6 +272,7 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
     {
         error("RDE: Null PLDM response received from Endpoint ID {EID}", "EID",
               eid_);
+        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
         updateState(OpState::OperationFailed);
         return;
     }
@@ -276,6 +280,7 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
     if (rxLen == 0)
     {
         error("RDE: rxLen is 0; Bad response Packet. EID={EID}", "EID", eid_);
+        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
         updateState(OpState::OperationFailed);
         return;
     }
@@ -291,6 +296,7 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
         error(
             "RDE: Failed to decode NegotiateMediumParameters response rc:{RC} cc:{CC}",
             "RC", rc, "CC", cc);
+        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
         updateState(OpState::OperationFailed);
         return;
     }
@@ -345,6 +351,8 @@ void DiscoverySession::runNextDictionaryCommand(size_t index)
     if (index >= majorSchemaResources_.size())
     {
         info("RDE: All schema dictionary commands completed.");
+        // Update negotiation status
+        device_->negotiationStatus(device_->NegotiationStatus::Success, false);
         return;
     }
 

--- a/rde/manager.cpp
+++ b/rde/manager.cpp
@@ -79,7 +79,7 @@ void Manager::createDeviceDbusObject(
     const std::vector<std::vector<uint8_t>>& pdrPayloads)
 {
     // Prevent duplicate creation for the same EID
-    if (eidMap_.count(eid()))
+    if (eidMap_.count(devEID))
     {
         info("Device for EID already exists. Skipping registration.");
         return;

--- a/rde/manager.cpp-bk
+++ b/rde/manager.cpp-bk
@@ -1,7 +1,6 @@
-#include "manager.hpp"
-
 #include "device.hpp"
 #include "device_common.hpp"
+#include "manager.hpp"
 
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus/match.hpp>
@@ -79,7 +78,7 @@ void Manager::createDeviceDbusObject(
     const std::vector<std::vector<uint8_t>>& pdrPayloads)
 {
     // Prevent duplicate creation for the same EID
-    if (eidMap_.count(eid()))
+    if (eidMap_.count(devEID))
     {
         info("Device for EID already exists. Skipping registration.");
         return;

--- a/rde/manager.hpp
+++ b/rde/manager.hpp
@@ -22,8 +22,7 @@ namespace pldm::rde
 
 inline constexpr std::string_view RDEManagerObjectPath{
     "/xyz/openbmc_project/RDE/Manager"};
-inline constexpr std::string_view DeviceObjectPath{
-    "/xyz/openbmc_project/RDE/Device"};
+constexpr const char* DeviceObjectPath = "/xyz/openbmc_project/RDE/Device";
 inline constexpr std::string_view DeviceServiceName{"xyz.openbmc_project.RDE"};
 
 using ObjectPath = sdbusplus::message::object_path;
@@ -305,6 +304,7 @@ class Manager :
     std::unordered_map<uint32_t, // OperationID
                        std::shared_ptr<OperationTaskIface>>
         taskMap_;
+    std::unique_ptr<sdbusplus::server::manager_t> objManager_;
 };
 
 } // namespace pldm::rde

--- a/rde/operation_session.cpp
+++ b/rde/operation_session.cpp
@@ -81,7 +81,7 @@ std::string OperationSession::getRootObjectName(const nlohmann::json& json)
             return odataType.substr(hashPos + 1, dotPos - hashPos - 1);
         }
     }
-    return "Root"; // fallback
+    return ""; // fallback
 }
 
 RedfishPropertyParent* OperationSession::createBejTree(

--- a/rde/operation_session.cpp
+++ b/rde/operation_session.cpp
@@ -256,7 +256,7 @@ void OperationSession::doOperationInit()
     int rc = 0;
     const std::string& resourceIdStr =
         device_->getRegistry()->getResourceIdFromUri(oipInfo.targetURI);
-    uint32_t currentResourceId_ =
+    currentResourceId_ =
         static_cast<uint32_t>(std::stoul(resourceIdStr));
     rde_op_id operationID = oipInfo.operationID;
     uint32_t sendDataTransferHandle;


### PR DESCRIPTION
Improve error handling and code cleanup for RDE code base to resolve following issues.
- Fix duplicate RDE device creation in pldmd.
- pldmd crash on multiple RDE device creation.
- Optimize URI construction logic.
- negotiation status update on failure.
- Few fixes in PATCH operation workflow.