### PR TITLE
RDEDeviceDetected Signal support

### DIFF
--- a/common/utils.cpp
+++ b/common/utils.cpp
@@ -568,6 +568,32 @@ int emitDiscoveryCompleteSignal(
     return PLDM_SUCCESS;
 }
 
+int emitRDEDeviceDetectedSignal(
+    uint8_t tid, eid mctpEid, pldm::UUID devUUID,
+    const std::vector<std::vector<uint8_t>>& pdrPayloads)
+{
+    try
+    {
+        auto& bus = DBusHandler::getBus();
+        auto msg = bus.new_signal("/xyz/openbmc_project/pldm",
+                                  "xyz.openbmc_project.PLDM.Event",
+                                  "RDEDeviceDetected");
+        msg.append(tid);
+        msg.append(mctpEid);
+        msg.append(devUUID);
+        msg.append(pdrPayloads);
+        msg.signal_send();
+    }
+    catch (const std::exception& e)
+    {
+        error("Failed to emit PLDM RDEDeviceDetected signal, error - {ERROR}",
+              "ERROR", e);
+        return PLDM_ERROR;
+    }
+
+    return PLDM_SUCCESS;
+}
+
 void recoverMctpEndpoint(const std::string& endpointObjPath)
 {
     auto& bus = DBusHandler::getBus();

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -528,6 +528,38 @@ int emitDiscoveryCompleteSignal(
     uint8_t tid, const std::vector<std::vector<uint8_t>>& pdrPayloads);
 
 /**
+ * @brief Emit the RDEDeviceDetected D-Bus signal
+ *
+ * Signal indicating that PLDM discovery has completed for a device that
+ * supports Redfish Device Enablement (RDE). This signal allows PLDM Requester
+ * applications to prepare for RDE negotiation and resource creation.
+ * Note: RDE-specific negotiation has not yet started at this point.
+ *
+ * Emits a D-Bus signal named `RDEDeviceDetected` with the terminus ID and a
+ * list of parsed Redfish Resource PDRs, each represented as a byte array
+ * suitable for D-Bus transmission.
+ *
+ * D-Bus Signature:
+ *     RDEDeviceDetected(uint8_t tid,
+ *                       uint8_t mctpEid,
+ *                       string deviceUUID,
+ *                       array<array<byte>> pdrPayloads)
+ *
+ * @param[in] tid Terminus ID from which the PDRs were discovered
+ * @param[in] mctpEid MCTP EID
+ * @param[in] deviceUUID - Uniquely identifies the target device instance.
+ * @param[in] pdrPayloads Vector of raw Redfish Resource PDR payloads,
+ *        each PDR as a vector of bytes (std::vector<uint8_t>)
+ * @return int Returns PLDM_SUCCESS on success, or PLDM_ERROR on failure.
+ *
+ * @exception Logs an error message if the signal emission fails due to an
+ * exception.
+ */
+int emitRDEDeviceDetectedSignal(
+    uint8_t tid, eid mctpEid, pldm::UUID devUUID,
+    const std::vector<std::vector<uint8_t>>& pdrPayloads);
+
+/**
  *  @brief call Recover() method to recover an MCTP Endpoint
  *  @param[in] MCTP Endpoint's object path
  */

--- a/platform-mc/platform_manager.cpp
+++ b/platform-mc/platform_manager.cpp
@@ -116,7 +116,18 @@ exec::task<int> PlatformManager::initTerminus()
 
         if (!redfishResources.empty())
         {
-            pldm::utils::emitDiscoveryCompleteSignal(tid, redfishResources);
+            auto info = terminusManager.getMctpInfoForTid(tid);
+            if (info)
+            {
+                pldm::utils::emitRDEDeviceDetectedSignal(
+                    tid, info->first, info->second, redfishResources);
+            }
+            else
+            {
+                lg2::error(
+                    "Failed to find Mctp Info for terminus with TID: {TID}",
+                    "TID", tid);
+            }
         }
 
         if (manager)

--- a/platform-mc/terminus_manager.cpp
+++ b/platform-mc/terminus_manager.cpp
@@ -773,5 +773,18 @@ std::optional<mctp_eid_t> TerminusManager::getActiveEidByName(
 
     return std::nullopt;
 }
+
+std::optional<std::pair<eid, UUID>> TerminusManager::getMctpInfoForTid(
+    pldm_tid_t tid)
+{
+    auto it = mctpInfoTable.find(tid);
+    if (it == mctpInfoTable.end())
+    {
+        return std::nullopt;
+    }
+
+    const auto& mctpInfo = it->second;
+    return std::make_pair(std::get<0>(mctpInfo), std::get<1>(mctpInfo));
+}
 } // namespace platform_mc
 } // namespace pldm

--- a/platform-mc/terminus_manager.hpp
+++ b/platform-mc/terminus_manager.hpp
@@ -181,6 +181,18 @@ class TerminusManager
     std::optional<mctp_eid_t> getActiveEidByName(
         const std::string& terminusName);
 
+    /**
+     * @brief Get the MCTP EID and UUID for a given PLDM TID.
+     *
+     * This function looks up the MCTP information associated with a specific
+     * PLDM Terminus ID (TID) from the internal mctpInfoTable.
+     *
+     * @param tid[in] The PLDM Terminus ID to look up.
+     * @return std::optional<std::pair<eid, UUID>> Returns a pair of EID and
+     * UUID if the TID is found, or std::nullopt if not found.
+     */
+    std::optional<std::pair<eid, UUID>> getMctpInfoForTid(pldm_tid_t tid);
+
   private:
     /** @brief Find the terminus object pointer in termini list.
      *

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -348,7 +348,7 @@ int main(int argc, char** argv)
     std::unique_ptr<MctpDiscovery> mctpDiscoveryHandler =
         std::make_unique<MctpDiscovery>(
             bus, std::initializer_list<MctpDiscoveryHandlerIntf*>{
-                     fwManager.get(), platformManager.get(), rdeManager.get()});
+                     fwManager.get(), platformManager.get()});
 
     auto callback = [verbose, &invoker, &reqHandler, &fwManager, &pldmTransport,
                      TID](IO& io, int fd, uint32_t revents) mutable {

--- a/rde/device.cpp
+++ b/rde/device.cpp
@@ -37,7 +37,7 @@ void Device::refreshDeviceInfo()
 
     try
     {
-        resourceRegistry_ = std::make_unique<ResourceRegistry>();
+        resourceRegistry_ = std::make_unique<ResourceRegistry>(eid(), this);
         resourceRegistry_->loadFromResourcePDR(pdrPayloads_);
         schemaResources(buildSchemaResourcesPayload());
 

--- a/rde/manager.hpp
+++ b/rde/manager.hpp
@@ -81,8 +81,7 @@ struct DeviceContext
  */
 class Manager :
     public sdbusplus::server::object::object<
-        sdbusplus::xyz::openbmc_project::RDE::server::Manager>,
-    public pldm::MctpDiscoveryHandlerIntf
+        sdbusplus::xyz::openbmc_project::RDE::server::Manager>
 {
   public:
     Manager(const Manager&) = delete;
@@ -217,44 +216,6 @@ class Manager :
     std::map<std::string,
              std::map<std::string, std::variant<int64_t, std::string>>>
         getDeviceSchemaInfo(std::string deviceUUID) override;
-
-    /** @brief Helper function to invoke registered handlers for
-     *         the added MCTP endpoints
-     *
-     *  @param[in] mctpInfos - information of discovered MCTP endpoints
-     */
-    void handleMctpEndpoints(const MctpInfos& mctpInfos) override;
-
-    /** @brief Helper function to invoke registered handlers for
-     *         the removed MCTP endpoints
-     *
-     *  @param[in] mctpInfos - information of removed MCTP endpoints
-     */
-    void handleRemovedMctpEndpoints(const MctpInfos&) override
-    {
-        return;
-    }
-
-    /** @brief Helper function to invoke registered handlers for
-     *  updating the availability status of the MCTP endpoint
-     *
-     *  @param[in] mctpInfo - information of the target endpoint
-     *  @param[in] availability - new availability status
-     */
-    void updateMctpEndpointAvailability(const MctpInfo&, Availability) override
-    {
-        return;
-    }
-
-    /** @brief Get Active EIDs.
-     *
-     *  @param[in] addr - MCTP address of terminus
-     *  @param[in] terminiNames - MCTP terminus name
-     */
-    std::optional<mctp_eid_t> getActiveEidByName(const std::string&) override
-    {
-        return std::nullopt;
-    }
 
     /**
      * @brief Create a device D-Bus object associated with PLDM discovery.

--- a/rde/manager.hpp
+++ b/rde/manager.hpp
@@ -298,6 +298,7 @@ class Manager :
     sdbusplus::bus::bus& bus_;
     sdeventplus::Event& event_;
     std::unordered_map<eid, DeviceContext> eidMap_;
+    std::unique_ptr<sdbusplus::bus::match_t> signalMatch_;
     std::unordered_map<eid, std::unique_ptr<sdbusplus::bus::match_t>>
         signalMatches_;
     // Registry of active OperationTask D-Bus objects.

--- a/rde/resource_registry.cpp
+++ b/rde/resource_registry.cpp
@@ -398,8 +398,10 @@ void ResourceRegistry::loadFromResourcePDR(
         registerResource(resourceId, info);
     }
 
-    // Need to replace with unique file name
-    saveToFile("/tmp/ResourceRegistry.txt");
+    constexpr const char* kResourceRegistryPrefix = "/tmp/ResourceRegistry_";
+    std::string filename =
+        std::string(kResourceRegistryPrefix) + std::to_string(entityId_);
+    saveToFile(filename);
 }
 
 } // namespace pldm::rde

--- a/rde/resource_registry.cpp
+++ b/rde/resource_registry.cpp
@@ -10,7 +10,7 @@
 namespace pldm::rde
 {
 
-ResourceRegistry::ResourceRegistry(uint16_t eid, void* parent) :
+ResourceRegistry::ResourceRegistry(const pldm::eid eid, void* parent) :
     entityId_(eid), parent_(parent)
 {}
 

--- a/rde/resource_registry.hpp
+++ b/rde/resource_registry.hpp
@@ -4,6 +4,8 @@
 
 #include <libpldm/platform.h>
 
+#include <common/types.hpp>
+
 extern "C"
 {
 #include "libpldm/rde.h"
@@ -57,7 +59,7 @@ class ResourceRegistry
      * @param[in] eid Entity ID identifying the device.
      * @param[in] parent Pointer to parent object for hierarchical access.
      */
-    explicit ResourceRegistry(uint16_t eid, void* parent = nullptr);
+    explicit ResourceRegistry(const pldm::eid eid, void* parent = nullptr);
 
     /**
      * @brief Register a resource and its schema metadata.
@@ -249,16 +251,16 @@ class ResourceRegistry
     std::vector<ResourceInfo> parseRedfishResourcePDRs(
         const std::vector<std::shared_ptr<pldm_redfish_resource_pdr>>& pdrList);
 
-    uint16_t entityId_;   // Entity ID of the associated device
-    void* parent_;        // Pointer to parent object for context
+    const pldm::eid entityId_; // Entity ID of the associated device
+    void* parent_;             // Pointer to parent object for context
     std::unordered_map<std::string, ResourceInfo>
-        resourceMap_;     // Map from resource ID to metadata
+        resourceMap_;          // Map from resource ID to metadata
     std::unordered_map<std::string, std::string>
-        uriToResourceId_; // URI to resource ID map
+        uriToResourceId_;      // URI to resource ID map
     std::unordered_map<std::string, std::string>
-        resourceIdToUri_; // Resource ID to URI map
+        resourceIdToUri_;      // Resource ID to URI map
     std::unordered_map<uint16_t, std::string>
-        classToUri_;      // Schema class to URI map
+        classToUri_;           // Schema class to URI map
 };
 
 } // namespace pldm::rde


### PR DESCRIPTION
Removed legacy MCTP endpoint-based device detection flow in favor of
a simplified signal-driven approach using `RDEDeviceDetected`.

The new flow relies on a single D-Bus signal emitted after PLDM
discovery completes, carrying all required context: TID, EID, UUID,
and Redfish Resource PDRs. This eliminates the need for separate
MCTP monitoring and reduces overall flow complexity.

All prerequisite changes—such as the addition of
`emitRDEDeviceDetectedSignal()` and the signal match registration in
PlatformManager—have already been introduced in earlier commits.