### PR TITLE
Add support for RDE cache management for SP8

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,6 +112,9 @@ if get_option('oem-ibm').allowed()
     conf_data.set('DMA_MAXSIZE', get_option('oem-ibm-dma-maxsize'))
     add_project_arguments('-DOEM_IBM', language: 'cpp')
 endif
+if get_option('oem-amd').allowed()
+    add_project_arguments('-DOEM_AMD', language: 'cpp')
+endif
 conf_data.set(
     'NUMBER_OF_REQUEST_RETRIES',
     get_option('number-of-request-retries'),

--- a/meson.options
+++ b/meson.options
@@ -179,6 +179,14 @@ option(
     value: 'enabled',
 )
 
+## OEM AMD Options
+option(
+    'oem-amd',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable AMD OEM PLDM',
+)
+
 ## Default Sensor Update Interval Options
 option(
     'default-sensor-update-interval',

--- a/rde/multipart_send.hpp
+++ b/rde/multipart_send.hpp
@@ -30,11 +30,10 @@ class Device;
  */
 struct MultipartSndMeta
 {
-    uint8_t schemaClass = 0;    ///< Schema class used for decoding.
-    uint8_t hasChecksum = true; ///< Indicates presence of checksum in chunk.
-    uint8_t isOpComplete =
-        false;               ///< True if the send operation is complete.
-    uint32_t nextHandle = 0; ///< Handle for the next chunk (if any).
+    uint8_t schemaClass = 0;      // Schema class used for decoding.
+    uint8_t hasChecksum = true;   // Indicates presence of checksum in chunk.
+    uint8_t isOpComplete = false; // True if the send operation is complete.
+    uint32_t nextHandle = 0;      // Handle for the next chunk (if any).
 };
 
 /**

--- a/rde/operation_session.cpp
+++ b/rde/operation_session.cpp
@@ -556,6 +556,10 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
                         {
                             info("Multipartsend completed");
                             multiPartTransferFlag = false;
+                            emitTaskUpdatedSignal(
+                                device_->getBus(), oipInfo.opTaskPath, "",
+                                static_cast<uint16_t>(
+                                    OpState::OperationCompleted));
                             doOperationComplete();
                         }
                         else
@@ -583,6 +587,10 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
                     "RID", currentResourceId_, "ERR", ex.what());
             }
         }
+        emitTaskUpdatedSignal(
+            device_->getBus(), oipInfo.opTaskPath, "",
+            static_cast<uint16_t>(OpState::OperationCompleted));
+        doOperationComplete();
     }
 
     return;


### PR DESCRIPTION
Caching Support for AMD SoC Endpoint
When the host is powered off, incoming cache requests for the AMD SoC endpoint are now cached.
The implementation includes:

Building the complete URI for the AMD SoC using rde_device_metadata.json file.
Triggering the Cache Manager through the CacheCreate D-Bus method.
Custom OperationInit request for Host Boot
The AMD SoC endpoint requires a special OperationInit command with a zero-length payload to boot once the cache processing.
The implementation includes:

Support to monitor the the cache replay signal upon completion of cache processing
Automatic issual of a zero-length OperationInit command once cache replay is finished.