### PR TITLE
pldmtool: Parse PLDM Type 6 (Redfish Device Enablement (RDE)) in a re…

### DIFF
--- a/pldmtool/pldm_base_cmd.cpp
+++ b/pldmtool/pldm_base_cmd.cpp
@@ -26,6 +26,7 @@ std::vector<std::unique_ptr<CommandInterface>> commands;
 const std::map<const char*, pldm_supported_types> pldmTypes{
     {"base", PLDM_BASE},   {"platform", PLDM_PLATFORM},
     {"bios", PLDM_BIOS},   {"fru", PLDM_FRU},
+    {"rde", PLDM_RDE},
 #ifdef OEM_IBM
     {"oem-ibm", PLDM_OEM},
 #endif


### PR DESCRIPTION
…sponse

Add parsing for PLDM Type 6 (Redfish Device Enablement (RDE)) in a response to the command GetPLDMTypes (0x4) of PLDM Base specification (DMTF DSP0240).