### PR TITLE
platform-mc: skip EID on discovery failure

### DIFF
--- a/platform-mc/terminus_manager.cpp
+++ b/platform-mc/terminus_manager.cpp
@@ -200,7 +200,12 @@ exec::task<int> TerminusManager::discoverMctpTerminusTask()
             if (it == termini.end())
             {
                 mctpInfoAvailTable[mctpInfo] = true;
-                co_await initMctpTerminus(mctpInfo);
+                auto rc = co_await initMctpTerminus(mctpInfo);
+                if(rc != PLDM_SUCCESS)
+                {
+                     mctpInfoAvailTable.erase(mctpInfo);
+                     continue;
+                }
             }
 
             /* Get TID of initialized terminus */


### PR DESCRIPTION
skip EID discovery upon failure to get TID from the endpoint.