### PR TITLE
pldmd: set eventReceiverAddressInfo field

### DIFF
--- a/platform-mc/terminus_manager.cpp
+++ b/platform-mc/terminus_manager.cpp
@@ -791,5 +791,28 @@ std::optional<std::pair<eid, UUID>> TerminusManager::getMctpInfoForTid(
     const auto& mctpInfo = it->second;
     return std::make_pair(std::get<0>(mctpInfo), std::get<1>(mctpInfo));
 }
+
+std::optional<uint8_t> TerminusManager::getBmcMctpEid()
+{
+	const std::string fileName = "/var/run/bmceid0";
+
+	try {
+		std::ifstream toDevice;
+
+		toDevice.exceptions(std::ios::failbit | std::ios::badbit);
+		toDevice.open(fileName);
+
+		uint8_t bmcMctpEid = 0;
+		toDevice.read(reinterpret_cast<char*>(&bmcMctpEid), sizeof(bmcMctpEid));
+
+		return bmcMctpEid;
+	}
+
+	catch (const std::ios_base::failure& iose) {
+		std::cerr << "In file I/O error: " << iose.what() << fileName << std::endl;
+	}
+
+	return std::nullopt;
+}
 } // namespace platform_mc
 } // namespace pldm

--- a/platform-mc/terminus_manager.hpp
+++ b/platform-mc/terminus_manager.hpp
@@ -152,7 +152,12 @@ class TerminusManager
      */
     mctp_eid_t getLocalEid()
     {
-        return localEid;
+	auto hostEid = getBmcMctpEid();
+
+	if (hostEid.has_value())
+		return *hostEid;
+
+	return localEid;
     }
 
     /** @brief Helper function to invoke registered handlers for
@@ -192,6 +197,17 @@ class TerminusManager
      * UUID if the TID is found, or std::nullopt if not found.
      */
     std::optional<std::pair<eid, UUID>> getMctpInfoForTid(pldm_tid_t tid);
+
+    /**
+     * @brief Get the BMC Host EID stored in a file
+     *
+     * This function looks up the a file and if the file exists and
+     * can be read, reads the MCTP EID stored in that file.
+     *
+     * @return std::optional<std::<uint8_t> Returns a BMC MCTP EID
+     * stored in the file and in case of any errors, return NULL value.
+     */
+    std::optional<uint8_t> getBmcMctpEid();
 
   private:
     /** @brief Find the terminus object pointer in termini list.


### PR DESCRIPTION
When sending request for command setEventReceiver, look up for eventReceiverAddressInfo in a file before assigning a default value.
eventReceiverAddressInfo is a BMC MCTP EID.