### PR TITLE
rde: Refresh EID on device rediscovery

### DIFF
--- a/configurations/pdr/com.amd.Hardware.Chassis/Processor0/16.json
+++ b/configurations/pdr/com.amd.Hardware.Chassis/Processor0/16.json
@@ -7,9 +7,7 @@
             "container_id": 0,
             "shared_name_count": 0,
             "name_string_count": 1,
-            "names": [
-                ["en", "Processor0"]
-            ]
+            "names": [["en", "Processor0"]]
         }
     ]
 }

--- a/oem/amd/platform-mc/platform_manager.cpp
+++ b/oem/amd/platform-mc/platform_manager.cpp
@@ -11,186 +11,224 @@
 
 PHOSPHOR_LOG2_USING;
 
-namespace pldm {
-namespace platform_mc {
+namespace pldm
+{
+namespace platform_mc
+{
 
-std::vector<uint16_t> convertToUtf16BE(const std::string &text) {
-  std::vector<uint16_t> utf16Data;
-  for (char c : text) {
-    utf16Data.push_back(htobe16(static_cast<uint16_t>(c)));
-  }
-  return utf16Data;
+std::vector<uint16_t> convertToUtf16BE(const std::string& text)
+{
+    std::vector<uint16_t> utf16Data;
+    for (char c : text)
+    {
+        utf16Data.push_back(htobe16(static_cast<uint16_t>(c)));
+    }
+    return utf16Data;
 }
 
-std::optional<std::vector<uint8_t>>
-decode_entity_auxiliary_names_pdr(const nlohmann::json &j) {
-  try {
-    size_t auxiliaryDataSize = 0;
-    const auto &names = j.at("names");
-    for (const auto &nameEntry : names) {
-      std::string lang = nameEntry.at(0).get<std::string>();
-      std::string text = nameEntry.at(1).get<std::string>();
+std::optional<std::vector<uint8_t>> decode_entity_auxiliary_names_pdr(
+    const nlohmann::json& j)
+{
+    try
+    {
+        size_t auxiliaryDataSize = 0;
+        const auto& names = j.at("names");
+        for (const auto& nameEntry : names)
+        {
+            std::string lang = nameEntry.at(0).get<std::string>();
+            std::string text = nameEntry.at(1).get<std::string>();
 
-      auxiliaryDataSize += (lang.size() + 1);     // Tag + null
-      auxiliaryDataSize += (text.size() * 2) + 2; // UTF16-BE + null
+            auxiliaryDataSize += (lang.size() + 1);     // Tag + null
+            auxiliaryDataSize += (text.size() * 2) + 2; // UTF16-BE + null
+        }
+
+        size_t totalSize = 18 + auxiliaryDataSize;
+
+        std::vector<uint8_t> pdrVec(totalSize, 0);
+        uint8_t* ptr = pdrVec.data();
+
+        auto hdr = reinterpret_cast<pldm_pdr_hdr*>(ptr);
+        hdr->version = 1;
+        hdr->type = PLDM_ENTITY_AUXILIARY_NAMES_PDR;
+        hdr->length = static_cast<uint16_t>(totalSize - sizeof(pldm_pdr_hdr));
+
+        size_t offset = sizeof(pldm_pdr_hdr);
+
+        pldm_entity container{};
+        container.entity_type = j.at("entity_type").get<uint16_t>();
+        container.entity_instance_num =
+            j.at("entity_instance_number").get<uint16_t>();
+        container.entity_container_id = j.at("container_id").get<uint16_t>();
+        std::memcpy(ptr + offset, &container, sizeof(container));
+        offset += sizeof(container);
+
+        ptr[offset++] = j.at("shared_name_count").get<uint8_t>();
+        ptr[offset++] = static_cast<uint8_t>(names.size());
+
+        for (const auto& nameEntry : names)
+        {
+            std::string lang = nameEntry.at(0).get<std::string>();
+            std::memcpy(ptr + offset, lang.c_str(), lang.size());
+            ptr[offset + lang.size()] = '\0';
+            offset += (lang.size() + 1);
+
+            std::string textStr = nameEntry.at(1).get<std::string>();
+            std::vector<uint16_t> utf16Data = convertToUtf16BE(textStr);
+
+            std::memcpy(ptr + offset, utf16Data.data(), utf16Data.size() * 2);
+            offset += (utf16Data.size() * 2);
+
+            ptr[offset++] = 0x00;
+            ptr[offset++] = 0x00;
+        }
+
+        lg2::info("Successfully encoded Auxiliary Name PDR, size: {SIZE}",
+                  "SIZE", totalSize);
+        return pdrVec;
     }
-
-    size_t totalSize = 18 + auxiliaryDataSize;
-
-    std::vector<uint8_t> pdrVec(totalSize, 0);
-    uint8_t *ptr = pdrVec.data();
-
-    auto hdr = reinterpret_cast<pldm_pdr_hdr *>(ptr);
-    hdr->version = 1;
-    hdr->type = PLDM_ENTITY_AUXILIARY_NAMES_PDR;
-    hdr->length = static_cast<uint16_t>(totalSize - sizeof(pldm_pdr_hdr));
-
-    size_t offset = sizeof(pldm_pdr_hdr);
-
-    pldm_entity container{};
-    container.entity_type = j.at("entity_type").get<uint16_t>();
-    container.entity_instance_num =
-        j.at("entity_instance_number").get<uint16_t>();
-    container.entity_container_id = j.at("container_id").get<uint16_t>();
-    std::memcpy(ptr + offset, &container, sizeof(container));
-    offset += sizeof(container);
-
-    ptr[offset++] = j.at("shared_name_count").get<uint8_t>();
-    ptr[offset++] = static_cast<uint8_t>(names.size());
-
-    for (const auto &nameEntry : names) {
-      std::string lang = nameEntry.at(0).get<std::string>();
-      std::memcpy(ptr + offset, lang.c_str(), lang.size());
-      ptr[offset + lang.size()] = '\0';
-      offset += (lang.size() + 1);
-
-      std::string textStr = nameEntry.at(1).get<std::string>();
-      std::vector<uint16_t> utf16Data = convertToUtf16BE(textStr);
-
-      std::memcpy(ptr + offset, utf16Data.data(), utf16Data.size() * 2);
-      offset += (utf16Data.size() * 2);
-
-      ptr[offset++] = 0x00;
-      ptr[offset++] = 0x00;
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to decode Auxiliary Names PDR: {ERR}", "ERR",
+                   e.what());
+        return std::nullopt;
     }
-
-    lg2::info("Successfully encoded Auxiliary Name PDR, size: {SIZE}", "SIZE",
-              totalSize);
-    return pdrVec;
-  } catch (const std::exception &e) {
-    lg2::error("Failed to decode Auxiliary Names PDR: {ERR}", "ERR", e.what());
-    return std::nullopt;
-  }
 }
 
-std::optional<std::vector<uint8_t>>
-decode_compact_numeric_sensor_pdr(const pldm_tid_t tid,
-                                  const nlohmann::json &j) {
-  try {
-    const std::string name = j.at("sensor_name").get<std::string>();
+std::optional<std::vector<uint8_t>> decode_compact_numeric_sensor_pdr(
+    const pldm_tid_t tid, const nlohmann::json& j)
+{
+    try
+    {
+        const std::string name = j.at("sensor_name").get<std::string>();
 
-    size_t pdrSize =
-        offsetof(pldm_compact_numeric_sensor_pdr, sensor_name) + name.size();
+        size_t pdrSize =
+            offsetof(pldm_compact_numeric_sensor_pdr, sensor_name) +
+            name.size();
 
-    std::vector<uint8_t> pdrVec(pdrSize, 0);
-    auto pdr =
-        reinterpret_cast<pldm_compact_numeric_sensor_pdr *>(pdrVec.data());
+        std::vector<uint8_t> pdrVec(pdrSize, 0);
+        auto pdr =
+            reinterpret_cast<pldm_compact_numeric_sensor_pdr*>(pdrVec.data());
 
-    pdr->hdr.type = j.at("pdr_type").get<uint16_t>();
-    pdr->terminus_handle = tid;
-    pdr->sensor_id = j.at("sensor_id").get<uint16_t>();
-    pdr->entity_type = j.at("entity_type").get<uint16_t>();
-    pdr->entity_instance = j.at("entity_instance_number").get<uint16_t>();
-    pdr->container_id = j.at("container_id").get<uint16_t>();
+        pdr->hdr.type = j.at("pdr_type").get<uint16_t>();
+        pdr->terminus_handle = tid;
+        pdr->sensor_id = j.at("sensor_id").get<uint16_t>();
+        pdr->entity_type = j.at("entity_type").get<uint16_t>();
+        pdr->entity_instance = j.at("entity_instance_number").get<uint16_t>();
+        pdr->container_id = j.at("container_id").get<uint16_t>();
 
-    pdr->sensor_name_length = static_cast<uint8_t>(name.size());
-    std::memcpy(pdr->sensor_name, name.data(), name.size());
+        pdr->sensor_name_length = static_cast<uint8_t>(name.size());
+        std::memcpy(pdr->sensor_name, name.data(), name.size());
 
-    pdr->base_unit = j.at("base_unit").get<uint8_t>();
-    pdr->unit_modifier = j.at("unit_modifier").get<int8_t>();
-    pdr->occurrence_rate = j.at("occurrence_rate").get<uint8_t>();
-    pdr->range_field_support.byte = j.at("range_field_support").get<uint8_t>();
+        pdr->base_unit = j.at("base_unit").get<uint8_t>();
+        pdr->unit_modifier = j.at("unit_modifier").get<int8_t>();
+        pdr->occurrence_rate = j.at("occurrence_rate").get<uint8_t>();
+        pdr->range_field_support.byte =
+            j.at("range_field_support").get<uint8_t>();
 
-    pdr->hdr.length = static_cast<uint16_t>(pdrVec.size() - 10);
-    uint16_t reportedLength = pdr->hdr.length;
+        pdr->hdr.length = static_cast<uint16_t>(pdrVec.size() - 10);
+        uint16_t reportedLength = pdr->hdr.length;
 
-    lg2::info("Successfully decoded Compact PDR: {NAME} of size: {PSIZE}",
-              "NAME", name, "PSIZE", reportedLength);
+        lg2::info("Successfully decoded Compact PDR: {NAME} of size: {PSIZE}",
+                  "NAME", name, "PSIZE", reportedLength);
 
-    return pdrVec;
-  } catch (const std::exception &e) {
-    lg2::error("Failed to decode Compact Numeric Sensor PDR: {ERR}", "ERR",
-               e.what());
-    return std::nullopt;
-  }
+        return pdrVec;
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to decode Compact Numeric Sensor PDR: {ERR}", "ERR",
+                   e.what());
+        return std::nullopt;
+    }
 }
 
 /* Setting default values when getPDRRepositoryInfo fails or does not support */
-exec::task<int>
-PlatformManager::get_pdr_from_json(std::shared_ptr<Terminus> terminus) {
-  pldm_tid_t tid = terminus->getTid();
+exec::task<int> PlatformManager::get_pdr_from_json(
+    std::shared_ptr<Terminus> terminus)
+{
+    pldm_tid_t tid = terminus->getTid();
 
-  std::string pdrDir = "/usr/share/pldm/pdr/com.amd.Hardware.Chassis";
-  if (!std::filesystem::exists(pdrDir)) {
-    co_return PLDM_ERROR_INVALID_DATA;
-  }
-
-  try {
-    // Only iterate immediate contents of pdrDir
-    for (const auto &subDir : std::filesystem::directory_iterator(pdrDir)) {
-      // IGNORE all files in the top pdrDir; only enter subdirectories
-      if (!subDir.is_directory()) {
-        continue;
-      }
-
-      // Only iterate immediate contents of the subdirectory (e.g.,
-      // 'Processor0')
-      for (const auto &subFile :
-           std::filesystem::directory_iterator(subDir.path())) {
-        // IGNORE everything except regular .json files
-        if (subFile.is_regular_file() &&
-            subFile.path().extension() == ".json") {
-
-          std::ifstream jsonFile(subFile.path());
-          auto jData = nlohmann::ordered_json::parse(jsonFile, nullptr, false);
-
-          if (jData.is_discarded()) {
-            lg2::error("Parsing JSON failed for {PATH}", "PATH",
-                       subFile.path().string());
-            continue; // Skip bad file, continue to next
-          }
-
-          for (const auto &[pdrName, pdrArray] : jData.items()) {
-            // Strict check: ignore keys that aren't arrays
-            if (!pdrArray.is_array()) {
-              continue;
-            }
-
-            for (const auto &pdrJson : pdrArray) {
-              if (pdrName == "entityAuxiliaryNamePDRs") {
-                if (auto pdrVec = decode_entity_auxiliary_names_pdr(pdrJson)) {
-                  terminus->pdrs.emplace_back(std::move(*pdrVec));
-                }
-              } else if (pdrName == "compactNumericSensorPDRs") {
-                if (auto pdrVec =
-                        decode_compact_numeric_sensor_pdr(tid, pdrJson)) {
-                  terminus->pdrs.emplace_back(std::move(*pdrVec));
-                }
-              }
-            }
-          }
-        }
-      }
+    std::string pdrDir = "/usr/share/pldm/pdr/com.amd.Hardware.Chassis";
+    if (!std::filesystem::exists(pdrDir))
+    {
+        co_return PLDM_ERROR_INVALID_DATA;
     }
-  } catch (const std::filesystem::filesystem_error &e) {
-    // lg2::error("Filesystem access error: {ERROR}", "ERROR", e.what());
-    lg2::error("Filesystem access error: {ERROR}, path: {PATH}",
-               "ERROR", e.what(),
-               "PATH", e.path1());
-    co_return PLDM_ERROR;
-  }
 
-  co_return PLDM_SUCCESS;
+    try
+    {
+        // Only iterate immediate contents of pdrDir
+        for (const auto& subDir : std::filesystem::directory_iterator(pdrDir))
+        {
+            // IGNORE all files in the top pdrDir; only enter subdirectories
+            if (!subDir.is_directory())
+            {
+                continue;
+            }
+
+            // Only iterate immediate contents of the subdirectory (e.g.,
+            // 'Processor0')
+            for (const auto& subFile :
+                 std::filesystem::directory_iterator(subDir.path()))
+            {
+                // IGNORE everything except regular .json files
+                if (subFile.is_regular_file() &&
+                    subFile.path().extension() == ".json")
+                {
+                    std::ifstream jsonFile(subFile.path());
+                    auto jData =
+                        nlohmann::ordered_json::parse(jsonFile, nullptr, false);
+
+                    if (jData.is_discarded())
+                    {
+                        lg2::error("Parsing JSON failed for {PATH}", "PATH",
+                                   subFile.path().string());
+                        continue; // Skip bad file, continue to next
+                    }
+
+                    for (const auto& [pdrName, pdrArray] : jData.items())
+                    {
+                        // Strict check: ignore keys that aren't arrays
+                        if (!pdrArray.is_array())
+                        {
+                            continue;
+                        }
+
+                        for (const auto& pdrJson : pdrArray)
+                        {
+                            if (pdrName == "entityAuxiliaryNamePDRs")
+                            {
+                                if (auto pdrVec =
+                                        decode_entity_auxiliary_names_pdr(
+                                            pdrJson))
+                                {
+                                    terminus->pdrs.emplace_back(
+                                        std::move(*pdrVec));
+                                }
+                            }
+                            else if (pdrName == "compactNumericSensorPDRs")
+                            {
+                                if (auto pdrVec =
+                                        decode_compact_numeric_sensor_pdr(
+                                            tid, pdrJson))
+                                {
+                                    terminus->pdrs.emplace_back(
+                                        std::move(*pdrVec));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+        // lg2::error("Filesystem access error: {ERROR}", "ERROR", e.what());
+        lg2::error("Filesystem access error: {ERROR}, path: {PATH}", "ERROR",
+                   e.what(), "PATH", e.path1());
+        co_return PLDM_ERROR;
+    }
+
+    co_return PLDM_SUCCESS;
 }
 
 } // namespace platform_mc

--- a/platform-mc/terminus.cpp
+++ b/platform-mc/terminus.cpp
@@ -533,16 +533,22 @@ std::shared_ptr<pldm_compact_numeric_sensor_pdr>
 
     std::shared_ptr<pldm_compact_numeric_sensor_pdr> parsedPdr;
 
-    if (pdr->sensor_name_length > 1) {
-      size_t totalSize = offsetof(pldm_compact_numeric_sensor_pdr, sensor_name) +
-        pdr->sensor_name_length;
-      auto completeBuffer = new uint8_t[totalSize];
+    if (pdr->sensor_name_length > 1)
+    {
+        size_t totalSize =
+            offsetof(pldm_compact_numeric_sensor_pdr, sensor_name) +
+            pdr->sensor_name_length;
+        auto completeBuffer = new uint8_t[totalSize];
 
-      parsedPdr = std::shared_ptr<pldm_compact_numeric_sensor_pdr>(
-         reinterpret_cast<pldm_compact_numeric_sensor_pdr*>(completeBuffer),
-         [] (pldm_compact_numeric_sensor_pdr* p) {delete [] reinterpret_cast<uint8_t *>(p);});
-    } else {
-       parsedPdr = std::make_shared<pldm_compact_numeric_sensor_pdr>();
+        parsedPdr = std::shared_ptr<pldm_compact_numeric_sensor_pdr>(
+            reinterpret_cast<pldm_compact_numeric_sensor_pdr*>(completeBuffer),
+            [](pldm_compact_numeric_sensor_pdr* p) {
+                delete[] reinterpret_cast<uint8_t*>(p);
+            });
+    }
+    else
+    {
+        parsedPdr = std::make_shared<pldm_compact_numeric_sensor_pdr>();
     }
 
     parsedPdr->hdr = pdr->hdr;
@@ -563,9 +569,10 @@ std::shared_ptr<pldm_compact_numeric_sensor_pdr>
     parsedPdr->fatal_high = pdr->fatal_high;
     parsedPdr->fatal_low = pdr->fatal_low;
 
-    if (pdr->sensor_name_length > 0) {
-     std::copy(pdr->sensor_name, pdr->sensor_name + pdr->sensor_name_length,
-       parsedPdr->sensor_name);
+    if (pdr->sensor_name_length > 0)
+    {
+        std::copy(pdr->sensor_name, pdr->sensor_name + pdr->sensor_name_length,
+                  parsedPdr->sensor_name);
     }
 
     return parsedPdr;

--- a/platform-mc/terminus_manager.cpp
+++ b/platform-mc/terminus_manager.cpp
@@ -794,25 +794,28 @@ std::optional<std::pair<eid, UUID>> TerminusManager::getMctpInfoForTid(
 
 std::optional<uint8_t> TerminusManager::getBmcMctpEid()
 {
-	const std::string fileName = "/var/run/bmceid0";
+    const std::string fileName = "/var/run/bmceid0";
 
-	try {
-		std::ifstream toDevice;
+    try
+    {
+        std::ifstream toDevice;
 
-		toDevice.exceptions(std::ios::failbit | std::ios::badbit);
-		toDevice.open(fileName);
+        toDevice.exceptions(std::ios::failbit | std::ios::badbit);
+        toDevice.open(fileName);
 
-		uint8_t bmcMctpEid = 0;
-		toDevice.read(reinterpret_cast<char*>(&bmcMctpEid), sizeof(bmcMctpEid));
+        uint8_t bmcMctpEid = 0;
+        toDevice.read(reinterpret_cast<char*>(&bmcMctpEid), sizeof(bmcMctpEid));
 
-		return bmcMctpEid;
-	}
+        return bmcMctpEid;
+    }
 
-	catch (const std::ios_base::failure& iose) {
-		std::cerr << "In file I/O error: " << iose.what() << fileName << std::endl;
-	}
+    catch (const std::ios_base::failure& iose)
+    {
+        std::cerr << "In file I/O error: " << iose.what() << fileName
+                  << std::endl;
+    }
 
-	return std::nullopt;
+    return std::nullopt;
 }
 } // namespace platform_mc
 } // namespace pldm

--- a/platform-mc/terminus_manager.hpp
+++ b/platform-mc/terminus_manager.hpp
@@ -152,12 +152,12 @@ class TerminusManager
      */
     mctp_eid_t getLocalEid()
     {
-	auto hostEid = getBmcMctpEid();
+        auto hostEid = getBmcMctpEid();
 
-	if (hostEid.has_value())
-		return *hostEid;
+        if (hostEid.has_value())
+            return *hostEid;
 
-	return localEid;
+        return localEid;
     }
 
     /** @brief Helper function to invoke registered handlers for

--- a/pldmtool/oem/amd/pldm_oem_amd.cpp
+++ b/pldmtool/oem/amd/pldm_oem_amd.cpp
@@ -1,4 +1,5 @@
 #include "pldm_oem_amd.hpp"
+
 #include "../../pldm_cmd_helper.hpp"
 
 namespace pldmtool
@@ -9,7 +10,8 @@ namespace oem_amd
 
 using namespace pldmtool::helper;
 
-namespace {
+namespace
+{
 std::vector<std::unique_ptr<CommandInterface>> commands;
 }
 
@@ -41,74 +43,90 @@ constexpr unsigned int MAX_FILE_SIZE = 0x4000;
 constexpr unsigned int AMD_IANA_NUM = 0xe78;
 constexpr unsigned int SFS_POLL_INTERVAL = 900;
 
-enum class SfsCommands{GETFWVER = 1, UPDATEFWVER};
-
-class AmdMctpSfsOp : public CommandInterface {
-public:
-  virtual ~AmdMctpSfsOp() = default;
-  AmdMctpSfsOp() = delete;
-  AmdMctpSfsOp(const AmdMctpSfsOp &) = delete;
-  AmdMctpSfsOp(AmdMctpSfsOp &&) = default;
-  AmdMctpSfsOp &operator=(const AmdMctpSfsOp &) = delete;
-  AmdMctpSfsOp &operator=(AmdMctpSfsOp &&) = delete;
-
-  explicit AmdMctpSfsOp(const char *type, const char *name, CLI::App *app, SfsCommands cmd)
-      : CommandInterface(type, name, app) {
-    mctpPreAllocTag = true;
-    pollInterval = SFS_POLL_INTERVAL;
-    sfsCmd = cmd;
-  }
-
-  const std::string getInFileName() const { return inFileName; }
-  const std::string getOutFileName() const { return outFileName; }
-  std::pair<int, std::vector<uint8_t>> createRequestMsg() override;
-  void parseResponseMsg(pldm_msg *, size_t) override;
-
-protected:
-  SfsCommands sfsCmd;
-  std::string outFileName{};
-  std::string inFileName{};
-  bool checksum{false};
-
-private:
-  std::vector<uint8_t> rawData{0x7F, 0x00, 0x00, 0x0E, 0x78, 0x80};
-
-  void appendInfile();
-  void handleSFSResponse(const uint8_t *, size_t);
+enum class SfsCommands
+{
+    GETFWVER = 1,
+    UPDATEFWVER
 };
 
-class GetFwVersion : public AmdMctpSfsOp {
-public:
-  explicit GetFwVersion(const char *type, const char *name, CLI::App *app)
-      : AmdMctpSfsOp(type, name, app, SfsCommands::GETFWVER) {
+class AmdMctpSfsOp : public CommandInterface
+{
+  public:
+    virtual ~AmdMctpSfsOp() = default;
+    AmdMctpSfsOp() = delete;
+    AmdMctpSfsOp(const AmdMctpSfsOp&) = delete;
+    AmdMctpSfsOp(AmdMctpSfsOp&&) = default;
+    AmdMctpSfsOp& operator=(const AmdMctpSfsOp&) = delete;
+    AmdMctpSfsOp& operator=(AmdMctpSfsOp&&) = delete;
 
-    app->add_option("-e,--network-id", mctpNetworkId, "MCTP NetworkId")
-        ->required();
-    app->add_option("-o,--file-out", outFileName,
-                    "Write out the received file");
-    app->add_flag("-c,--checksum", checksum, "Append/Validate checksum");
-    app->footer(R"(Example:
+    explicit AmdMctpSfsOp(const char* type, const char* name, CLI::App* app,
+                          SfsCommands cmd) : CommandInterface(type, name, app)
+    {
+        mctpPreAllocTag = true;
+        pollInterval = SFS_POLL_INTERVAL;
+        sfsCmd = cmd;
+    }
+
+    const std::string getInFileName() const
+    {
+        return inFileName;
+    }
+    const std::string getOutFileName() const
+    {
+        return outFileName;
+    }
+    std::pair<int, std::vector<uint8_t>> createRequestMsg() override;
+    void parseResponseMsg(pldm_msg*, size_t) override;
+
+  protected:
+    SfsCommands sfsCmd;
+    std::string outFileName{};
+    std::string inFileName{};
+    bool checksum{false};
+
+  private:
+    std::vector<uint8_t> rawData{0x7F, 0x00, 0x00, 0x0E, 0x78, 0x80};
+
+    void appendInfile();
+    void handleSFSResponse(const uint8_t*, size_t);
+};
+
+class GetFwVersion : public AmdMctpSfsOp
+{
+  public:
+    explicit GetFwVersion(const char* type, const char* name, CLI::App* app) :
+        AmdMctpSfsOp(type, name, app, SfsCommands::GETFWVER)
+    {
+        app->add_option("-e,--network-id", mctpNetworkId, "MCTP NetworkId")
+            ->required();
+        app->add_option("-o,--file-out", outFileName,
+                        "Write out the received file");
+        app->add_flag("-c,--checksum", checksum, "Append/Validate checksum");
+        app->footer(R"(Example:
       pldmtool amdMctpSfs getFwVersion -m 21 -e 1 --file-out resp.bin
       pldmtool amdMctpSfs getFwVersion -m 21 -e 1 --file-out resp.bin --checksum)");
-  }
+    }
 };
 
-class UpdateFwVersion : public AmdMctpSfsOp {
-public:
-  explicit UpdateFwVersion(const char *type, const char *name, CLI::App *app)
-      : AmdMctpSfsOp(type, name, app, SfsCommands::UPDATEFWVER) {
-
-    app->add_option("-e,--network-id", mctpNetworkId, "MCTP NetworkId")
-        ->required();
-    app->add_option("-i,--file-in", inFileName, "Read in the file to be sent");
-    app->add_option("-o,--file-out", outFileName,
-                    "Write out the received file");
-    app->add_flag("-c,--checksum", checksum, "Append/Validate checksum");
-    app->footer(R"(Example: 
+class UpdateFwVersion : public AmdMctpSfsOp
+{
+  public:
+    explicit UpdateFwVersion(const char* type, const char* name,
+                             CLI::App* app) :
+        AmdMctpSfsOp(type, name, app, SfsCommands::UPDATEFWVER)
+    {
+        app->add_option("-e,--network-id", mctpNetworkId, "MCTP NetworkId")
+            ->required();
+        app->add_option("-i,--file-in", inFileName,
+                        "Read in the file to be sent");
+        app->add_option("-o,--file-out", outFileName,
+                        "Write out the received file");
+        app->add_flag("-c,--checksum", checksum, "Append/Validate checksum");
+        app->footer(R"(Example: 
       pldmtool amdMctpSfs updateFwVersion -m 21 -e 1 --file-in req.bin
       pldmtool amdMctpSfs updateFwVersion -m 21 -e 1 --file-in req.bin --checksum
       pldmtool amdMctpSfs updateFwVersion -m 21 -e 1 --file-in req.bin --file-out /tmp/resp.bin --checksum)");
-  }
+    }
 };
 
 /**
@@ -123,11 +141,13 @@ public:
  * @return The value represented in big-endian byte order.
  */
 
-template <typename T> constexpr T convToBigEndian(T value) {
-  if constexpr (std::endian::native == std::endian::little)
-    return std::byteswap(value);
-  else
-    return value;
+template <typename T>
+constexpr T convToBigEndian(T value)
+{
+    if constexpr (std::endian::native == std::endian::little)
+        return std::byteswap(value);
+    else
+        return value;
 }
 
 /**
@@ -153,54 +173,64 @@ template <typename T> constexpr T convToBigEndian(T value) {
  * reallocations.
  */
 
-void AmdMctpSfsOp::appendInfile() {
-  std::uintmax_t fSize = 0;
-  std::ifstream toDevice;
-  std::vector<uint8_t> fData;
+void AmdMctpSfsOp::appendInfile()
+{
+    std::uintmax_t fSize = 0;
+    std::ifstream toDevice;
+    std::vector<uint8_t> fData;
 
-  try {
-    fSize = std::filesystem::file_size(getInFileName());
-  } catch (const std::filesystem::filesystem_error &fse) {
-    std::cerr << "File size error: " << fse.what() << std::endl;
-    return;
-  }
+    try
+    {
+        fSize = std::filesystem::file_size(getInFileName());
+    }
+    catch (const std::filesystem::filesystem_error& fse)
+    {
+        std::cerr << "File size error: " << fse.what() << std::endl;
+        return;
+    }
 
-  if (!fSize) {
-    std::cerr << "Empty file: " << getInFileName() << std::endl;
-    return;
-  }
+    if (!fSize)
+    {
+        std::cerr << "Empty file: " << getInFileName() << std::endl;
+        return;
+    }
 
-  try {
-    toDevice.exceptions(std::ios::failbit | std::ios::badbit);
+    try
+    {
+        toDevice.exceptions(std::ios::failbit | std::ios::badbit);
 
-    toDevice.open(getInFileName(), std::ios::binary);
+        toDevice.open(getInFileName(), std::ios::binary);
 
-    fData.resize(fSize);
+        fData.resize(fSize);
 
-    toDevice.read(reinterpret_cast<char *>(fData.data()),
-                  static_cast<std::streamsize>(fSize));
-  } catch (const std::ios_base::failure &iose) {
-    std::cerr << "In file I/O error: " << iose.what() << getInFileName()
-              << std::endl;
-    return;
-  }
+        toDevice.read(reinterpret_cast<char*>(fData.data()),
+                      static_cast<std::streamsize>(fSize));
+    }
+    catch (const std::ios_base::failure& iose)
+    {
+        std::cerr << "In file I/O error: " << iose.what() << getInFileName()
+                  << std::endl;
+        return;
+    }
 
-  // Reserve expected additional (in) payload size
-  std::size_t reserveSize = FS_FIELD + fSize + (checksum ? CS_FIELD : 0);
-  rawData.reserve(rawData.size() + reserveSize);
+    // Reserve expected additional (in) payload size
+    std::size_t reserveSize = FS_FIELD + fSize + (checksum ? CS_FIELD : 0);
+    rawData.reserve(rawData.size() + reserveSize);
 
-  uint32_t fsField = convToBigEndian(static_cast<uint32_t>(fSize));
-  auto fsValue = std::bit_cast<std::array<uint8_t, sizeof(fsField)>>(fsField);
-  rawData.insert(rawData.end(), fsValue.begin(), fsValue.end());
+    uint32_t fsField = convToBigEndian(static_cast<uint32_t>(fSize));
+    auto fsValue = std::bit_cast<std::array<uint8_t, sizeof(fsField)>>(fsField);
+    rawData.insert(rawData.end(), fsValue.begin(), fsValue.end());
 
-  rawData.insert(rawData.end(), fData.begin(), fData.end());
+    rawData.insert(rawData.end(), fData.begin(), fData.end());
 
-  if (checksum) {
-    uint32_t csField = convToBigEndian(
-        static_cast<uint32_t>(pldm_edac_crc32(fData.data(), fData.size())));
-    auto csValue = std::bit_cast<std::array<uint8_t, sizeof(csField)>>(csField);
-    rawData.insert(rawData.end(), csValue.begin(), csValue.end());
-  }
+    if (checksum)
+    {
+        uint32_t csField = convToBigEndian(
+            static_cast<uint32_t>(pldm_edac_crc32(fData.data(), fData.size())));
+        auto csValue =
+            std::bit_cast<std::array<uint8_t, sizeof(csField)>>(csField);
+        rawData.insert(rawData.end(), csValue.begin(), csValue.end());
+    }
 }
 
 /** @brief Creates a raw MCTP request message.
@@ -212,16 +242,17 @@ void AmdMctpSfsOp::appendInfile() {
  *  @return A pair containing the PLDM status code and the modified raw data.
  */
 
-std::pair<int, std::vector<uint8_t>> AmdMctpSfsOp::createRequestMsg() {
-  rawData.push_back(static_cast<uint8_t>(sfsCmd));
+std::pair<int, std::vector<uint8_t>> AmdMctpSfsOp::createRequestMsg()
+{
+    rawData.push_back(static_cast<uint8_t>(sfsCmd));
 
-  if (checksum)
-     rawData.at(0) |= 0x80; // set the IC bit (bit 7 [0:7]) e.g. 0x7F to 0xFF
+    if (checksum)
+        rawData.at(0) |= 0x80; // set the IC bit (bit 7 [0:7]) e.g. 0x7F to 0xFF
 
-  if (!getInFileName().empty()) // only for the -i option
-     appendInfile();
+    if (!getInFileName().empty()) // only for the -i option
+        appendInfile();
 
-  return {PLDM_SUCCESS, rawData};
+    return {PLDM_SUCCESS, rawData};
 }
 
 /*
@@ -247,90 +278,101 @@ std::pair<int, std::vector<uint8_t>> AmdMctpSfsOp::createRequestMsg() {
  *       with fields in big-endian format as defined by the device protocol.
  */
 
-void AmdMctpSfsOp::handleSFSResponse(const uint8_t *msg, size_t size) {
-  // Check Completion Code (byte)
-  if (msg[COMP_CODE_BYTE] != 0) {
-    std::cerr << "Command failed with completion code: " << msg[COMP_CODE_BYTE]
-              << std::endl;
-    return;
-  }
-
-  if (size < (DEV_HDR_SIZE + FS_FIELD)) {
-    std::cerr << "Received response size," << size
-              << " does not include size of the file" << std::endl;
-    return;
-  }
-
-  // Extract four bytes to obtain the received file size
-  uint32_t fSize;
-
-  std::memcpy(&fSize, msg + DEV_HDR_SIZE,
-              sizeof(fSize)); // File size is in Big endian format as per spec
-  fSize = convToBigEndian(fSize);
-
-  if (fSize > MAX_FILE_SIZE) {
-    std::cerr << "Error: File size " << fSize << " exceeds maximum limit of "
-              << MAX_FILE_SIZE << std::endl;
-    return;
-  }
-
-  // If -o option is not specified, nothing to write to
-  if (getOutFileName().empty())
-    return;
-
-  if (size < (DEV_HDR_SIZE + FS_FIELD + fSize)) {
-    std::cerr << "Received response of " << size
-              << " bytes shorter than expected size of "
-              << ((DEV_HDR_SIZE + FS_FIELD + fSize)) << std::endl;
-    return;
-  }
-
-  std::vector<uint8_t> fData{msg + DEV_HDR_SIZE + FS_FIELD,
-                             msg + DEV_HDR_SIZE + FS_FIELD + fSize};
-
-  if (checksum) {
-    if (size < (DEV_HDR_SIZE + FS_FIELD + fSize + CS_FIELD)) {
-      std::cerr << "Received response of " << size
-                << " bytes does not contain checksum" << std::endl;
-      return;
+void AmdMctpSfsOp::handleSFSResponse(const uint8_t* msg, size_t size)
+{
+    // Check Completion Code (byte)
+    if (msg[COMP_CODE_BYTE] != 0)
+    {
+        std::cerr << "Command failed with completion code: "
+                  << msg[COMP_CODE_BYTE] << std::endl;
+        return;
     }
 
-    // Calculate checksum
-    const uint32_t crc = pldm_edac_crc32(fData.data(), fData.size());
-
-    // Extract four bytes of checksum
-    uint32_t checkSum;
-
-    std::memcpy(
-        &checkSum, msg + DEV_HDR_SIZE + FS_FIELD + fSize,
-        sizeof(checkSum)); // Checksum is in Big endian format as per spec
-    checkSum = convToBigEndian(checkSum);
-
-    if (crc != checkSum) {
-      std::cerr << std::showbase << std::hex << "CRC: " << crc
-                << " does not match the received CRC: " << checkSum
-                << std::endl;
-      return;
+    if (size < (DEV_HDR_SIZE + FS_FIELD))
+    {
+        std::cerr << "Received response size," << size
+                  << " does not include size of the file" << std::endl;
+        return;
     }
-  }
 
-  std::ofstream fromDevice;
+    // Extract four bytes to obtain the received file size
+    uint32_t fSize;
 
-  try {
-    fromDevice.exceptions(std::ios::failbit | std::ios::badbit);
+    std::memcpy(&fSize, msg + DEV_HDR_SIZE,
+                sizeof(fSize)); // File size is in Big endian format as per spec
+    fSize = convToBigEndian(fSize);
 
-    fromDevice.open(getOutFileName(), std::ios::binary);
+    if (fSize > MAX_FILE_SIZE)
+    {
+        std::cerr << "Error: File size " << fSize
+                  << " exceeds maximum limit of " << MAX_FILE_SIZE << std::endl;
+        return;
+    }
 
-    fromDevice.write(reinterpret_cast<const char *>(fData.data()),
-                     fData.size());
+    // If -o option is not specified, nothing to write to
+    if (getOutFileName().empty())
+        return;
 
-    std::cerr << "Created file: " << getOutFileName()
-              << " of size (in bytes): " << fData.size() << std::endl;
-  } catch (const std::ios_base::failure &iose) {
-    std::cerr << "Out file I/O error: " << iose.what() << getOutFileName()
-              << std::endl;
-    return;
-  }
+    if (size < (DEV_HDR_SIZE + FS_FIELD + fSize))
+    {
+        std::cerr << "Received response of " << size
+                  << " bytes shorter than expected size of "
+                  << ((DEV_HDR_SIZE + FS_FIELD + fSize)) << std::endl;
+        return;
+    }
+
+    std::vector<uint8_t> fData{msg + DEV_HDR_SIZE + FS_FIELD,
+                               msg + DEV_HDR_SIZE + FS_FIELD + fSize};
+
+    if (checksum)
+    {
+        if (size < (DEV_HDR_SIZE + FS_FIELD + fSize + CS_FIELD))
+        {
+            std::cerr << "Received response of " << size
+                      << " bytes does not contain checksum" << std::endl;
+            return;
+        }
+
+        // Calculate checksum
+        const uint32_t crc = pldm_edac_crc32(fData.data(), fData.size());
+
+        // Extract four bytes of checksum
+        uint32_t checkSum;
+
+        std::memcpy(
+            &checkSum, msg + DEV_HDR_SIZE + FS_FIELD + fSize,
+            sizeof(checkSum)); // Checksum is in Big endian format as per spec
+        checkSum = convToBigEndian(checkSum);
+
+        if (crc != checkSum)
+        {
+            std::cerr << std::showbase << std::hex << "CRC: " << crc
+                      << " does not match the received CRC: " << checkSum
+                      << std::endl;
+            return;
+        }
+    }
+
+    std::ofstream fromDevice;
+
+    try
+    {
+        fromDevice.exceptions(std::ios::failbit | std::ios::badbit);
+
+        fromDevice.open(getOutFileName(), std::ios::binary);
+
+        fromDevice.write(reinterpret_cast<const char*>(fData.data()),
+                         fData.size());
+
+        std::cerr << "Created file: " << getOutFileName()
+                  << " of size (in bytes): " << fData.size() << std::endl;
+    }
+    catch (const std::ios_base::failure& iose)
+    {
+        std::cerr << "Out file I/O error: " << iose.what() << getOutFileName()
+                  << std::endl;
+        return;
+    }
 }
 
 /*
@@ -356,58 +398,62 @@ void AmdMctpSfsOp::handleSFSResponse(const uint8_t *msg, size_t size) {
  *       with fields in big-endian format as defined by the device protocol.
  */
 
-void AmdMctpSfsOp::parseResponseMsg(pldm_msg *pmsg, size_t size) {
-  // If this response is not for one of the file sharing protocols (e.g. SFS),
-  // return
-  if ((rawData.at(0) & 0x7F) != 0x7F)
-    return;
+void AmdMctpSfsOp::parseResponseMsg(pldm_msg* pmsg, size_t size)
+{
+    // If this response is not for one of the file sharing protocols (e.g. SFS),
+    // return
+    if ((rawData.at(0) & 0x7F) != 0x7F)
+        return;
 
-  if (!pmsg)
-    return;
+    if (!pmsg)
+        return;
 
-  // Add back the size, that response receiver deducts for PLDM message header
-  // does not apply in this case.
-  size += sizeof(pldm_msg_hdr);
+    // Add back the size, that response receiver deducts for PLDM message header
+    // does not apply in this case.
+    size += sizeof(pldm_msg_hdr);
 
-  if (size < DEV_HDR_SIZE) {
-    std::cerr << "Invalid respose size (in bytes): " << size
-              << ", minimum expected response size: " << DEV_HDR_SIZE
-              << std::endl;
-    return;
-  }
+    if (size < DEV_HDR_SIZE)
+    {
+        std::cerr << "Invalid respose size (in bytes): " << size
+                  << ", minimum expected response size: " << DEV_HDR_SIZE
+                  << std::endl;
+        return;
+    }
 
-  const uint8_t *msg{reinterpret_cast<uint8_t *>(pmsg)};
+    const uint8_t* msg{reinterpret_cast<uint8_t*>(pmsg)};
 
-  // Extract four bytes of IANA number to verify
-  uint32_t iana;
-  memcpy(&iana, msg, sizeof(iana)); // IANA number in big endian format
-  iana = convToBigEndian(iana);
-  if (iana != AMD_IANA_NUM) {
-    std::cerr << std::showbase << std::hex << "Received IANA number: " << iana
-              << " does not match with: " << AMD_IANA_NUM << std::endl;
-    return;
-  }
+    // Extract four bytes of IANA number to verify
+    uint32_t iana;
+    memcpy(&iana, msg, sizeof(iana)); // IANA number in big endian format
+    iana = convToBigEndian(iana);
+    if (iana != AMD_IANA_NUM)
+    {
+        std::cerr << std::showbase << std::hex
+                  << "Received IANA number: " << iana
+                  << " does not match with: " << AMD_IANA_NUM << std::endl;
+        return;
+    }
 
-  // Check SubType
-  if ((rawData.at(SUB_TYPE_BYTE) & 0xF) == SUBTYPE_SFS)
-    handleSFSResponse(msg, size);
+    // Check SubType
+    if ((rawData.at(SUB_TYPE_BYTE) & 0xF) == SUBTYPE_SFS)
+        handleSFSResponse(msg, size);
 }
 
-void registerCommand(CLI::App &app) {
-  auto amdMctpSfs = app.add_subcommand(
-      "amdMctpSfs", "AMD SFS commands");
-  amdMctpSfs->require_subcommand(1);
+void registerCommand(CLI::App& app)
+{
+    auto amdMctpSfs = app.add_subcommand("amdMctpSfs", "AMD SFS commands");
+    amdMctpSfs->require_subcommand(1);
 
-  auto getFwVersion =
-      amdMctpSfs->add_subcommand("getFwVersion", "Get Firmware Version");
-  commands.push_back(
-      std::make_unique<GetFwVersion>("amdMctpSfs", "GetFwVersion", getFwVersion));
+    auto getFwVersion =
+        amdMctpSfs->add_subcommand("getFwVersion", "Get Firmware Version");
+    commands.push_back(std::make_unique<GetFwVersion>(
+        "amdMctpSfs", "GetFwVersion", getFwVersion));
 
-  auto updateFwVersion =
-      amdMctpSfs->add_subcommand("updateFwVersion", "Update Firmware Version");
-  commands.push_back(
-      std::make_unique<UpdateFwVersion>("amdMctpSfs", "UpdateFwVersion", updateFwVersion));
+    auto updateFwVersion = amdMctpSfs->add_subcommand(
+        "updateFwVersion", "Update Firmware Version");
+    commands.push_back(std::make_unique<UpdateFwVersion>(
+        "amdMctpSfs", "UpdateFwVersion", updateFwVersion));
 }
 
-} // oem_amd 
+} // namespace oem_amd
 } // namespace pldmtool

--- a/pldmtool/pldm_cmd_helper.cpp
+++ b/pldmtool/pldm_cmd_helper.cpp
@@ -90,8 +90,7 @@ void fillCompletionCode(uint8_t completionCode, ordered_json& data,
 }
 
 int mctpSockSendRecv(const uint8_t mctpNetworkId, const uint8_t eid,
-                     const bool mctpPreAllocTag,
-                     const uint16_t pollInterval,
+                     const bool mctpPreAllocTag, const uint16_t pollInterval,
                      const std::vector<uint8_t>& requestMsg,
                      void** responseMessage, size_t* responseMessageSize)
 {
@@ -169,8 +168,8 @@ int mctpSockSendRecv(const uint8_t mctpNetworkId, const uint8_t eid,
     rc = poll(&pollfd, 1, pollInterval * 1000);
     if (rc < 0)
     {
-        std::cerr << "poll(AF_MCTP, " << pollInterval << ") failed. errnostr = "
-                  << strerror(errno) << "\n";
+        std::cerr << "poll(AF_MCTP, " << pollInterval
+                  << ") failed. errnostr = " << strerror(errno) << "\n";
         close(sd);
         return rc;
     }
@@ -279,10 +278,11 @@ int CommandInterface::pldmSendRecv(std::vector<uint8_t>& requestMsg,
 
     if (CommandInterface::pldmType == "amdMctpSfs")
     {
-       std::cout << "pldmtool: ";
-       size_t printLen = std::min(requestMsg.size(), static_cast<size_t>(32));
-       std::vector<uint8_t> partialMsg(requestMsg.begin(), requestMsg.begin() + printLen);
-       printBuffer(Tx, partialMsg);
+        std::cout << "pldmtool: ";
+        size_t printLen = std::min(requestMsg.size(), static_cast<size_t>(32));
+        std::vector<uint8_t> partialMsg(requestMsg.begin(),
+                                        requestMsg.begin() + printLen);
+        printBuffer(Tx, partialMsg);
     }
 
     auto tid = mctp_eid;
@@ -295,7 +295,8 @@ int CommandInterface::pldmSendRecv(std::vector<uint8_t>& requestMsg,
         void* responseMessage = nullptr;
         size_t responseMessageSize{};
 
-        if (CommandInterface::pldmType != "mctpRaw" && CommandInterface::pldmType != "amdMctpSfs")
+        if (CommandInterface::pldmType != "mctpRaw" &&
+            CommandInterface::pldmType != "amdMctpSfs")
         {
             rc = pldmTransport.sendRecvMsg(tid, requestMsg.data(),
                                            requestMsg.size(), responseMessage,
@@ -336,10 +337,12 @@ int CommandInterface::pldmSendRecv(std::vector<uint8_t>& requestMsg,
 
         if (CommandInterface::pldmType == "amdMctpSfs")
         {
-           std::cout << "pldmtool: ";
-           size_t printLen = std::min(responseMsg.size(), static_cast<size_t>(32));
-           std::vector<uint8_t> partialMsg(responseMsg.begin(), responseMsg.begin() + printLen);
-           printBuffer(Rx, partialMsg);
+            std::cout << "pldmtool: ";
+            size_t printLen =
+                std::min(responseMsg.size(), static_cast<size_t>(32));
+            std::vector<uint8_t> partialMsg(responseMsg.begin(),
+                                            responseMsg.begin() + printLen);
+            printBuffer(Rx, partialMsg);
         }
     }
 

--- a/pldmtool/pldmtool.cpp
+++ b/pldmtool/pldmtool.cpp
@@ -4,8 +4,8 @@
 #include "pldm_fru_cmd.hpp"
 #include "pldm_fw_update_cmd.hpp"
 #include "pldm_platform_cmd.hpp"
-#include "pldmtool/oem/ibm/pldm_oem_ibm.hpp"
 #include "pldmtool/oem/amd/pldm_oem_amd.hpp"
+#include "pldmtool/oem/ibm/pldm_oem_ibm.hpp"
 
 #include <CLI/CLI.hpp>
 

--- a/rde/device.cpp
+++ b/rde/device.cpp
@@ -51,10 +51,10 @@ void Device::refreshDeviceInfo()
         dictionaryManager_ =
             std::make_unique<pldm::rde::DictionaryManager>(deviceUUID());
 
-        std::shared_ptr<Device> self;
+        std::weak_ptr<Device> self;
         try
         {
-            self = shared_from_this();
+            self = weak_from_this();
         }
         catch (const std::bad_weak_ptr& e)
         {
@@ -96,15 +96,10 @@ void Device::performRDEOperation(const OperationInfo& oipInfo)
 {
     info("Operation Session Started");
 
-    std::shared_ptr<Device> self;
+    std::weak_ptr<Device> self;
     try
     {
-        self = shared_from_this();
-        if (!self)
-        {
-            error("Device::shared_from_this() returned null shared_ptr");
-            return;
-        }
+        self = weak_from_this();
     }
     catch (const std::bad_weak_ptr& e)
     {
@@ -225,7 +220,29 @@ DeviceState Device::getState() const
 
 void Device::updateState(DeviceState newState)
 {
+    if (newState == DeviceState::NotReady ||
+        newState == DeviceState::Unreachable ||
+        newState == DeviceState::Disabled)
+    {
+        discovSession_.reset();
+        opSession_.reset();
+        resourceRegistry_.reset();
+        dictionaryManager_.reset();
+        this->negotiationStatus(NegotiationStatus::NotStarted);
+    }
+
     currentState_ = newState;
+}
+
+void Device::shutdown()
+{
+    shuttingDown_ = true;
+
+    if (opSession_)
+        opSession_.reset();
+
+    if (discovSession_)
+        discovSession_.reset();
 }
 
 SchemaResourcesType Device::buildSchemaResourcesPayload() const

--- a/rde/device.hpp
+++ b/rde/device.hpp
@@ -205,6 +205,8 @@ class Device : public EntryIfaces, public std::enable_shared_from_this<Device>
         return bus_;
     }
 
+    void shutdown();
+
   private:
     /**
      * @brief Constructs schema resource payload based on discovered resources.
@@ -234,6 +236,7 @@ class Device : public EntryIfaces, public std::enable_shared_from_this<Device>
     std::unique_ptr<pldm::rde::DictionaryManager> dictionaryManager_;
     std::unique_ptr<DiscoverySession> discovSession_;
     std::unique_ptr<OperationSession> opSession_;
+    bool shuttingDown_;
 };
 
 } // namespace pldm::rde

--- a/rde/discov_session.cpp
+++ b/rde/discov_session.cpp
@@ -18,24 +18,20 @@ PHOSPHOR_LOG2_USING;
 
 namespace pldm::rde
 {
-DiscoverySession::DiscoverySession(std::shared_ptr<Device> device) :
-    device_(std::move(device)), eid_(device_->eid()), tid_(device_->getTid()),
-    currentState_(OpState::Idle)
+DiscoverySession::DiscoverySession(std::weak_ptr<Device> device) :
+    device_(std::move(device)), currentState_(OpState::Idle)
 {
-    info(
-        "RDE: DiscoverySession created for EID={EID},TID={TID}, use_count={COUNT}",
-        "EID", static_cast<int>(eid_), "TID", tid_, "COUNT",
-        device_.use_count());
-
-    // Optional: log pointers if debugging deep ownership
-    if (!device_)
+    auto dev = device_.lock();
+    if (!dev)
     {
+        eid_ = 0;
+        tid_ = 0;
         error("RDE:DiscoverySession received null device pointer!");
+        return;
     }
 
-    // Optional: print address for deep tracking
-    debug("RDE:DiscoverySession bound to Device instance at address={ADDR}",
-          "ADDR", static_cast<const void*>(device_.get()));
+    eid_ = dev->eid();
+    tid_ = dev->getTid();
 }
 
 void DiscoverySession::updateState(OpState newState)
@@ -54,8 +50,13 @@ void DiscoverySession::sendRDECommand(
 {
     info("RDE: sendRDECommand Start: EID={EID} InstanceID={IID}, Command={CMD}",
          "EID", eid, "IID", instanceId, "CMD", command);
-
-    int rc = device_->getHandler()->registerRequest(
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        error("OperationSession: device expired");
+        return;
+    }
+    int rc = dev->getHandler()->registerRequest(
         eid, instanceId, PLDM_RDE, command, std::move(request),
         [callback,
          device = device_](uint8_t /*eid*/, const pldm_msg* respMsg,
@@ -64,7 +65,7 @@ void DiscoverySession::sendRDECommand(
     {
         error("RDE: Failed to send command {CMD} to EID={EID}, RC={RC}", "CMD",
               command, "EID", eid, "RC", rc);
-        device_->getInstanceIdDb().free(eid, instanceId);
+        dev->getInstanceIdDb().free(eid, instanceId);
         return;
     }
 
@@ -74,15 +75,20 @@ void DiscoverySession::sendRDECommand(
 void DiscoverySession::doNegotiateRedfish()
 {
     info("RDE: NegotiateRedfishParameters  Enter");
-
-    auto instanceId = device_->getInstanceIdDb().next(eid_);
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        error("OperationSession: device expired");
+        return;
+    }
+    auto instanceId = dev->getInstanceIdDb().next(eid_);
 
     Request request(
         sizeof(pldm_msg_hdr) + PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_REQ_BYTES);
     auto requestMsg = new (request.data()) pldm_msg;
 
     // Variant-safe: Extract mcFeatureSupport
-    const auto& featureMeta = device_->getMetadataField("mcFeatureSupport");
+    const auto& featureMeta = dev->getMetadataField("mcFeatureSupport");
     const auto* featureSupport = std::get_if<FeatureSupport>(&featureMeta);
     if (!featureSupport)
     {
@@ -96,8 +102,7 @@ void DiscoverySession::doNegotiateRedfish()
     mcFeatureBits.value = featureSupport->value;
 
     // Variant-safe: Extract mcConcurrencySupport
-    const auto& concurrencyMeta =
-        device_->getMetadataField("mcConcurrencySupport");
+    const auto& concurrencyMeta = dev->getMetadataField("mcConcurrencySupport");
     const auto* concurrencySupport = std::get_if<uint8_t>(&concurrencyMeta);
     if (!concurrencySupport)
     {
@@ -121,7 +126,7 @@ void DiscoverySession::doNegotiateRedfish()
             "RDE: encode NegotiateRedfishParameters request EID '{EID}', RC '{RC}'",
             "EID", eid_, "RC", rc);
         updateState(OpState::OperationFailed);
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         return;
     }
 
@@ -137,7 +142,12 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
 {
     info("RDE: handleNegotiateRedfishResp Start: EID={EID} rxLen={RXLEN}",
          "EID", eid_, "RXLEN", rxLen);
-
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        error("OperationSession: device expired");
+        return;
+    }
     if (currentState_ == OpState::TimedOut ||
         currentState_ == OpState::Cancelled)
     {
@@ -151,7 +161,7 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
         error("RDE: Null PLDM response received from endpoint ID {EID}", "EID",
               eid_);
         updateState(OpState::OperationFailed);
-        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
+        dev->negotiationStatus(dev->NegotiationStatus::Failed, false);
         return;
     }
 
@@ -160,7 +170,7 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
         error("RDE:rxLen is 0; applying fallback length. EID={EID}", "EID",
               eid_);
         updateState(OpState::OperationFailed);
-        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
+        dev->negotiationStatus(dev->NegotiationStatus::Failed, false);
         return;
     }
 
@@ -181,7 +191,7 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
             "RDE: Failed to decode NegotiateRedfishParameters response rc:{RC} cc:{CC}",
             "RC", rc, "CC", cc);
         updateState(OpState::OperationFailed);
-        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
+        dev->negotiationStatus(dev->NegotiationStatus::Failed, false);
         return;
     }
 
@@ -195,12 +205,12 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
         "CONCURRENCY", devConcurrency, "FEATURE", features.value, "CAPS",
         caps.value);
 
-    if (device_)
+    if (dev)
     {
-        device_->setMetadataField("deviceConcurrencySupport", devConcurrency);
-        device_->setMetadataField("devCapabilities", caps);
-        device_->setMetadataField("devFeatureSupport", features);
-        device_->setMetadataField("devConfigSignature", configSig);
+        dev->setMetadataField("deviceConcurrencySupport", devConcurrency);
+        dev->setMetadataField("devCapabilities", caps);
+        dev->setMetadataField("devFeatureSupport", features);
+        dev->setMetadataField("devConfigSignature", configSig);
     }
 
     info("RDE: NegotiateRedfishParameters Command completed");
@@ -212,15 +222,20 @@ void DiscoverySession::handleNegotiateRedfishResp(const pldm_msg* respMsg,
 void DiscoverySession::doNegotiateMediumParams()
 {
     info("RDE: NegotiateMediumParameters Enter EID={EID}", "EID", eid_);
-
-    auto instanceId = device_->getInstanceIdDb().next(eid_);
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        error("OperationSession: device expired");
+        return;
+    }
+    auto instanceId = dev->getInstanceIdDb().next(eid_);
 
     Request request(
         sizeof(pldm_msg_hdr) + PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_REQ_BYTES);
     auto requestMsg = new (request.data()) pldm_msg;
 
     const auto& chunkMeta =
-        device_->getMetadataField("mcMaxTransferChunkSizeBytes");
+        dev->getMetadataField("mcMaxTransferChunkSizeBytes");
     const auto* chunkSizePtr = std::get_if<uint32_t>(&chunkMeta);
     if (!chunkSizePtr)
     {
@@ -243,7 +258,7 @@ void DiscoverySession::doNegotiateMediumParams()
         error(
             "RDE: Encoding NegotiateMediumParameters failed: EID={EID}, RC={RC}",
             "EID", eid_, "RC", rc);
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         return;
     }
 
@@ -259,7 +274,12 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
 {
     info("RDE: handleNegotiateMediumResp Start: EID={EID} rxLen={RXLEN}", "EID",
          eid_, "RXLEN", rxLen);
-
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        error("OperationSession: device expired");
+        return;
+    }
     if (currentState_ == OpState::TimedOut ||
         currentState_ == OpState::Cancelled)
     {
@@ -272,7 +292,7 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
     {
         error("RDE: Null PLDM response received from Endpoint ID {EID}", "EID",
               eid_);
-        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
+        dev->negotiationStatus(dev->NegotiationStatus::Failed, false);
         updateState(OpState::OperationFailed);
         return;
     }
@@ -280,7 +300,7 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
     if (rxLen == 0)
     {
         error("RDE: rxLen is 0; Bad response Packet. EID={EID}", "EID", eid_);
-        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
+        dev->negotiationStatus(dev->NegotiationStatus::Failed, false);
         updateState(OpState::OperationFailed);
         return;
     }
@@ -296,7 +316,7 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
         error(
             "RDE: Failed to decode NegotiateMediumParameters response rc:{RC} cc:{CC}",
             "RC", rc, "CC", cc);
-        device_->negotiationStatus(device_->NegotiationStatus::Failed, false);
+        dev->negotiationStatus(dev->NegotiationStatus::Failed, false);
         updateState(OpState::OperationFailed);
         return;
     }
@@ -305,8 +325,8 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
         "RDE: NegotiateMediumParameters response: EID={EID}, DeviceMaxTransfer={SIZE}",
         "EID", eid_, "SIZE", devMaxTransferChunkSizeBytes);
 
-    device_->setMetadataField("devMaxTransferChunkSizeBytes",
-                              devMaxTransferChunkSizeBytes);
+    dev->setMetadataField("devMaxTransferChunkSizeBytes",
+                          devMaxTransferChunkSizeBytes);
 
     info("RDE: NegotiateMediumParameters Command completed");
 
@@ -316,6 +336,12 @@ void DiscoverySession::handleNegotiateMediumResp(const pldm_msg* respMsg,
 
 void DiscoverySession::getDictionaries()
 {
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        error("OperationSession: device expired");
+        return;
+    }
     const std::string triggerFile = "/tmp/.enable_dict_bootstrap";
     if (std::filesystem::exists(triggerFile))
     {
@@ -324,7 +350,7 @@ void DiscoverySession::getDictionaries()
     }
 
     // Collect all applicable resource IDs from device's registry
-    const auto& resourceMap = device_->getRegistry()->getResourceMap();
+    const auto& resourceMap = dev->getRegistry()->getResourceMap();
 
     for (const auto& [rid, info] : resourceMap)
     {
@@ -339,20 +365,26 @@ void DiscoverySession::getDictionaries()
 
     // Schedule the first dictionary command using a deferred source
     dictionaryDefer_ = std::make_unique<sdeventplus::source::Defer>(
-        device_->getEvent(), [this](sdeventplus::source::EventBase&) {
+        dev->getEvent(), [this](sdeventplus::source::EventBase&) {
             this->runNextDictionaryCommand(resourceIndex_);
         });
 }
 
 void DiscoverySession::runNextDictionaryCommand(size_t index)
 {
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        error("OperationSession: device expired");
+        return;
+    }
     dictionaryDefer_.reset();
 
     if (index >= majorSchemaResources_.size())
     {
         info("RDE: All schema dictionary commands completed.");
         // Update negotiation status
-        device_->negotiationStatus(device_->NegotiationStatus::Success, false);
+        dev->negotiationStatus(dev->NegotiationStatus::Success, false);
         return;
     }
 
@@ -365,7 +397,7 @@ void DiscoverySession::runNextDictionaryCommand(size_t index)
 
     resourceIndex_ = index + 1;
 
-    auto instanceId = device_->getInstanceIdDb().next(eid_);
+    auto instanceId = dev->getInstanceIdDb().next(eid_);
 
     size_t payloadLength =
         sizeof(pldm_msg_hdr) + PLDM_RDE_SCHEMA_DICTIONARY_REQ_BYTES;
@@ -377,10 +409,10 @@ void DiscoverySession::runNextDictionaryCommand(size_t index)
     if (rc != PLDM_SUCCESS)
     {
         error("RDE: Encoding GetSchemaDictionary failed: RC={RC}", "RC", rc);
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
 
         dictionaryDefer_ = std::make_unique<sdeventplus::source::Defer>(
-            device_->getEvent(), [this](sdeventplus::source::EventBase&) {
+            dev->getEvent(), [this](sdeventplus::source::EventBase&) {
                 this->runNextDictionaryCommand(resourceIndex_);
             });
 
@@ -400,13 +432,19 @@ void DiscoverySession::runNextDictionaryCommand(size_t index)
 void DiscoverySession::handleGetSchemaDictionaryResp(const pldm_msg* respMsg,
                                                      size_t rxLen)
 {
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        error("OperationSession: device expired");
+        return;
+    }
     if (!respMsg || rxLen == 0)
     {
         error("RDE: Invalid response for resourceId={RID}", "RID",
               currentResourceId_);
 
         dictionaryDefer_ = std::make_unique<sdeventplus::source::Defer>(
-            device_->getEvent(), [this](sdeventplus::source::EventBase&) {
+            dev->getEvent(), [this](sdeventplus::source::EventBase&) {
                 this->runNextDictionaryCommand(resourceIndex_);
             });
         return;
@@ -426,7 +464,7 @@ void DiscoverySession::handleGetSchemaDictionaryResp(const pldm_msg* respMsg,
             "RID", currentResourceId_, "RC", rc, "CC", cc);
 
         dictionaryDefer_ = std::make_unique<sdeventplus::source::Defer>(
-            device_->getEvent(), [this](sdeventplus::source::EventBase&) {
+            dev->getEvent(), [this](sdeventplus::source::EventBase&) {
                 this->runNextDictionaryCommand(resourceIndex_);
             });
         return;
@@ -443,7 +481,10 @@ void DiscoverySession::handleGetSchemaDictionaryResp(const pldm_msg* respMsg,
         receiver_->start(
             [this](std::span<const uint8_t> payload,
                    const pldm::rde::MultipartRcvMeta& meta) {
-                auto* dictMgr = device_->getDictionaryManager();
+                auto dev = device_.lock();
+                if (!dev)
+                    return;
+                auto* dictMgr = dev->getDictionaryManager();
                 if (!dictMgr)
                 {
                     error(
@@ -469,7 +510,7 @@ void DiscoverySession::handleGetSchemaDictionaryResp(const pldm_msg* respMsg,
                 {
                     dictionaryDefer_ =
                         std::make_unique<sdeventplus::source::Defer>(
-                            device_->getEvent(),
+                            dev->getEvent(),
                             [this](sdeventplus::source::EventBase&) {
                                 this->runNextDictionaryCommand(resourceIndex_);
                                 receiver_.reset();

--- a/rde/discov_session.hpp
+++ b/rde/discov_session.hpp
@@ -46,7 +46,7 @@ class DiscoverySession
      * @param[in] device A reference to the Device object containing discovery
      * dependencies.
      */
-    explicit DiscoverySession(std::shared_ptr<Device> device);
+    explicit DiscoverySession(std::weak_ptr<Device> device);
 
     DiscoverySession() = delete;
     DiscoverySession(const DiscoverySession&) = delete;
@@ -167,7 +167,7 @@ class DiscoverySession
     void handleGetSchemaDictionaryResp(const pldm_msg* respMsg, size_t rxLen);
 
   private:
-    std::shared_ptr<Device> device_;
+    std::weak_ptr<Device> device_;
     pldm::eid eid_;
     pldm_tid_t tid_;
     bool initialized_ = false;

--- a/rde/manager.cpp
+++ b/rde/manager.cpp
@@ -53,7 +53,48 @@ Manager::Manager(sdbusplus::bus::bus& bus, sdeventplus::Event& event,
                 this->createDeviceDbusObject(signalEid, devUUID, signalTid,
                                              pdrPayloads);
             }
+            else
+            {
+                removeDeviceByEid(signalEid);
+                this->createDeviceDbusObject(signalEid, devUUID, signalTid,
+                                             pdrPayloads);
+            }
         });
+}
+
+void Manager::removeDeviceByEid(eid devEID)
+{
+    auto it = eidMap_.find(devEID);
+    if (it == eidMap_.end())
+    {
+        info("removeDeviceByEid: EID {EID} not found", "EID",
+             static_cast<int>(devEID));
+        return;
+    }
+
+    std::shared_ptr<Device> dev = it->second.devicePtr;
+
+    info("removeDeviceByEid: removing device EID {EID}", "EID",
+         static_cast<int>(devEID));
+
+    if (dev)
+    {
+        try
+        {
+            dev->shutdown();
+        }
+        catch (const std::exception& e)
+        {
+            error("removeDeviceByEid: shutdown exception EID {EID}: {ERR}",
+                  "EID", static_cast<int>(devEID), "ERR", e.what());
+        }
+    }
+
+    eidMap_.erase(it);
+    dev.reset();
+
+    info("removeDeviceByEid: removed device EID {EID}", "EID",
+         static_cast<int>(devEID));
 }
 
 void Manager::createDeviceDbusObject(
@@ -137,7 +178,7 @@ void Manager::createDeviceDbusObject(
                                  taskPathStr};
 
             opSession_ = std::make_unique<OperationSession>(
-                eidMap_[devEid].devicePtr, opInfo);
+                std::weak_ptr<Device>(eidMap_[devEid].devicePtr), opInfo);
             if (!opSession_)
             {
                 error("RDEReplayComplete: Failed to send zero length request");

--- a/rde/manager.hpp
+++ b/rde/manager.hpp
@@ -86,7 +86,8 @@ struct DeviceContext
  */
 class Manager :
     public sdbusplus::server::object::object<
-        sdbusplus::xyz::openbmc_project::RDE::server::Manager>
+        sdbusplus::xyz::openbmc_project::RDE::server::
+            Manager>
 {
   public:
     Manager(const Manager&) = delete;
@@ -257,6 +258,22 @@ class Manager :
     {
         return taskMap_;
     }
+
+    /**
+     * @brief Remove a device context identified by its PLDM EID.
+     *
+     * This method looks up the device associated with the given EID in the
+     * internal EID map and performs a controlled teardown of its context.
+     * If a valid device object exists, its shutdown routine is invoked to
+     * stop any ongoing operations and release associated resources.
+     *
+     * After shutdown, the device smart pointer is reset and the corresponding
+     * entry is removed from the internal EID tracking map. If the EID is not
+     * found, the call is a no-op and a log message is emitted.
+     *
+     * @param devEID[in] PLDM Endpoint ID (EID) of the device to be removed.
+     */
+    void removeDeviceByEid(eid devEID);
 
 #ifdef OEM_AMD
     pldm::eid getEidFromUuid(const UUID& uuid) const

--- a/rde/multipart_recv.cpp
+++ b/rde/multipart_recv.cpp
@@ -12,8 +12,8 @@ PHOSPHOR_LOG2_USING;
 namespace pldm::rde
 {
 
-MultipartReceiver::MultipartReceiver(std::shared_ptr<Device> device,
-                                     uint8_t eid, uint32_t transferHandle) :
+MultipartReceiver::MultipartReceiver(std::weak_ptr<Device> device, uint8_t eid,
+                                     uint32_t transferHandle) :
     device_(std::move(device)), eid_(eid), transferHandle_(transferHandle)
 {}
 
@@ -32,7 +32,15 @@ void MultipartReceiver::start(
 
 void MultipartReceiver::sendReceiveRequest(uint32_t handle)
 {
-    uint8_t instanceId = device_->getInstanceIdDb().next(eid_);
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        if (onFailure_)
+            onFailure_("Device expired");
+        return;
+    }
+
+    uint8_t instanceId = dev->getInstanceIdDb().next(eid_);
 
     lg2::debug("RDE: Allocated Instance ID={ID} for EID={EID}", "ID",
                instanceId, "EID", eid_);
@@ -52,7 +60,7 @@ void MultipartReceiver::sendReceiveRequest(uint32_t handle)
                                               transferOperation_, requestMsg);
     if (rc != PLDM_SUCCESS)
     {
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         lg2::error("RDE: Request encoding failed: RC={RC}, EID={EID}", "RC", rc,
                    "EID", eid_);
         if (onFailure_)
@@ -60,7 +68,7 @@ void MultipartReceiver::sendReceiveRequest(uint32_t handle)
         return;
     }
 
-    rc = device_->getHandler()->registerRequest(
+    rc = dev->getHandler()->registerRequest(
         eid_, instanceId, PLDM_RDE, PLDM_RDE_MULTIPART_RECEIVE,
         std::move(request),
         [this](uint8_t /*eid*/, const pldm_msg* msg, size_t len) {
@@ -69,7 +77,7 @@ void MultipartReceiver::sendReceiveRequest(uint32_t handle)
 
     if (rc)
     {
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         lg2::error("RDE: Request registration failed: RC={RC}, EID={EID}", "RC",
                    rc, "EID", eid_);
         if (onFailure_)
@@ -80,6 +88,13 @@ void MultipartReceiver::sendReceiveRequest(uint32_t handle)
 void MultipartReceiver::handleReceiveResp(const pldm_msg* respMsg, size_t rxLen)
 {
     lg2::info("RDE: :handleReceiveResp LEN={LEN}", "LEN", rxLen);
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        if (onFailure_)
+            onFailure_("Device expired");
+        return;
+    }
 
     if (!respMsg || rxLen == 0)
     {
@@ -103,7 +118,7 @@ void MultipartReceiver::handleReceiveResp(const pldm_msg* respMsg, size_t rxLen)
     }
 
     const auto& chunkMeta =
-        device_->getMetadataField("devMaxTransferChunkSizeBytes");
+        dev->getMetadataField("devMaxTransferChunkSizeBytes");
     const auto* chunkSizePtr = std::get_if<uint32_t>(&chunkMeta);
     if (!chunkSizePtr)
     {

--- a/rde/multipart_recv.hpp
+++ b/rde/multipart_recv.hpp
@@ -52,7 +52,7 @@ class MultipartReceiver
      * @param eid Target device endpoint ID
      * @param transferHandle Initial dictionary transfer handle
      */
-    MultipartReceiver(std::shared_ptr<Device> device, uint8_t eid,
+    MultipartReceiver(std::weak_ptr<Device> device, uint8_t eid,
                       uint32_t transferHandle);
 
     /**
@@ -100,7 +100,7 @@ class MultipartReceiver
     }
 
   private:
-    std::shared_ptr<Device> device_;             // Target device
+    std::weak_ptr<Device> device_;               // Target device
     uint8_t eid_;                                // Endpoint ID
     uint32_t transferHandle_;                    // Current transfer handle
     std::function<void(std::span<const uint8_t>, const MultipartRcvMeta&)>

--- a/rde/multipart_send.cpp
+++ b/rde/multipart_send.cpp
@@ -6,7 +6,7 @@
 namespace pldm::rde
 {
 
-MultipartSender::MultipartSender(std::shared_ptr<Device> device, uint8_t eid,
+MultipartSender::MultipartSender(std::weak_ptr<Device> device, uint8_t eid,
                                  std::vector<uint8_t> dataPayload) :
     device_(std::move(device)), eid_(eid), dataPayload_(dataPayload)
 {}
@@ -34,7 +34,14 @@ void MultipartSender::setTransferFlag(uint8_t flag)
 
 void MultipartSender::sendRequest(uint32_t handle)
 {
-    const auto& meta = device_->getMetadataField("mcMaxTransferChunkSizeBytes");
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        if (onFailure_)
+            onFailure_("Device expired");
+        return;
+    }
+    const auto& meta = dev->getMetadataField("mcMaxTransferChunkSizeBytes");
     const auto* maxChunkSizePtr = std::get_if<uint32_t>(&meta);
     if (!maxChunkSizePtr)
     {
@@ -54,7 +61,14 @@ void MultipartSender::sendRequest(uint32_t handle)
 
 void MultipartSender::sendReceiveRequest(uint32_t handle)
 {
-    const auto& meta = device_->getMetadataField("mcMaxTransferChunkSizeBytes");
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        if (onFailure_)
+            onFailure_("Device expired");
+        return;
+    }
+    const auto& meta = dev->getMetadataField("mcMaxTransferChunkSizeBytes");
     const auto* maxChunkSizePtr = std::get_if<uint32_t>(&meta);
     if (!maxChunkSizePtr)
     {
@@ -89,7 +103,14 @@ bool MultipartSender::sendMultipartCommand(
     uint32_t handle, rde_op_id operationID, uint8_t transferFlag,
     const std::vector<uint8_t>& payload, uint32_t checksum)
 {
-    uint8_t instanceId = device_->getInstanceIdDb().next(eid_);
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        if (onFailure_)
+            onFailure_("Device expired");
+        return false;
+    }
+    uint8_t instanceId = dev->getInstanceIdDb().next(eid_);
 
     uint32_t dataLength = payload.size();
     Request request(sizeof(pldm_msg_hdr) +
@@ -107,13 +128,13 @@ bool MultipartSender::sendMultipartCommand(
         const_cast<uint8_t*>(payload.data()), checksum, requestMsg);
     if (rc != PLDM_SUCCESS)
     {
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         if (onFailure_)
             onFailure_("Request encoding failed");
         return false;
     }
 
-    rc = device_->getHandler()->registerRequest(
+    rc = dev->getHandler()->registerRequest(
         eid_, instanceId, PLDM_RDE, PLDM_RDE_MULTIPART_SEND, std::move(request),
         [this](uint8_t, const pldm_msg* msg, size_t len) {
             this->handleSendResp(msg, len);
@@ -121,7 +142,7 @@ bool MultipartSender::sendMultipartCommand(
 
     if (rc)
     {
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         if (onFailure_)
             onFailure_("Request registration failed");
         return false;

--- a/rde/multipart_send.hpp
+++ b/rde/multipart_send.hpp
@@ -52,7 +52,7 @@ class MultipartSender
      * @param eid Device endpoint ID.
      * @param dataPayload The request payload data.
      */
-    MultipartSender(std::shared_ptr<Device> device, uint8_t eid,
+    MultipartSender(std::weak_ptr<Device> device, uint8_t eid,
                     std::vector<uint8_t> dataPayload);
 
     /**
@@ -119,7 +119,7 @@ class MultipartSender
                               const std::vector<uint8_t>& payload,
                               uint32_t checksum);
 
-    std::shared_ptr<Device> device_;   // Target device abstraction.
+    std::weak_ptr<Device> device_;     // Target device abstraction.
     uint8_t eid_;                      // Device endpoint ID.
     uint32_t transferHandle_ = 1;      // Current multipart transfer handle.
     rde_op_id operationID_;            // Current transfer operation phase.

--- a/rde/operation_session.cpp
+++ b/rde/operation_session.cpp
@@ -28,13 +28,18 @@ constexpr auto rdeCacheManagerInterface =
 namespace pldm::rde
 {
 
-OperationSession::OperationSession(std::shared_ptr<Device> device,
-                                   struct OperationInfo oipInfo) :
-    device_(std::move(device)), eid_(device_->eid()),
-    currentState_(OpState::Idle), oipInfo(oipInfo)
+OperationSession::OperationSession(std::weak_ptr<Device> device,
+                                   OperationInfo oipInfo) :
+    device_(std::move(device)), oipInfo(oipInfo)
 {
-    info("RDE: OperationSession created for EID={EID},use_count={COUNT}", "EID",
-         static_cast<int>(eid_), "COUNT", device_.use_count());
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        eid_ = 0;
+        return;
+    }
+
+    eid_ = dev->eid(); // or dev->getEid()
 }
 
 void OperationSession::updateState(OpState newState)
@@ -176,7 +181,8 @@ inline BejDictionaries OperationSession::getDictionaries()
 {
     try
     {
-        if (device_ == nullptr || device_->getDictionaryManager() == nullptr)
+        auto dev = device_.lock();
+        if (!dev || dev->getDictionaryManager() == nullptr)
         {
             lg2::error(
                 "RDE: DictionaryManager unavailable for resourceId={RID}",
@@ -185,12 +191,12 @@ inline BejDictionaries OperationSession::getDictionaries()
         }
 
         std::span<const uint8_t> schemaDict =
-            device_->getDictionaryManager()
+            dev->getDictionaryManager()
                 ->get(currentResourceId_, bejMajorSchemaClass)
                 ->getDictionaryBytes();
 
         std::span<const uint8_t> annotDict =
-            device_->getDictionaryManager()
+            dev->getDictionaryManager()
                 ->getAnnotationDictionary()
                 ->getDictionaryBytes();
 
@@ -391,11 +397,16 @@ void createCache(std::string targetURI, OperationType operationType,
 
 void OperationSession::doOperationInit()
 {
-    auto instanceId = device_->getInstanceIdDb().next(eid_);
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        return; // Device already destroyed
+    }
+    auto instanceId = dev->getInstanceIdDb().next(eid_);
 
     int rc = 0;
     const std::string& resourceIdStr =
-        device_->getRegistry()->getResourceIdFromUri(oipInfo.targetURI);
+        dev->getRegistry()->getResourceIdFromUri(oipInfo.targetURI);
     currentResourceId_ = static_cast<uint32_t>(std::stoul(resourceIdStr));
     rde_op_id operationID = oipInfo.operationID;
     uint32_t sendDataTransferHandle;
@@ -432,7 +443,7 @@ void OperationSession::doOperationInit()
                     "EID", oipInfo.eid, "URI", oipInfo.targetURI, "PAYLOAD",
                     oipInfo.payload);
                 updateState(OpState::OperationFailed);
-                device_->getInstanceIdDb().free(eid_, instanceId);
+                dev->getInstanceIdDb().free(eid_, instanceId);
                 return;
             }
 
@@ -443,7 +454,7 @@ void OperationSession::doOperationInit()
                     "BEJ encode failed: produced empty payload. EID '{EID}', URI '{URI}'",
                     "EID", oipInfo.eid, "URI", oipInfo.targetURI);
                 updateState(OpState::OperationFailed);
-                device_->getInstanceIdDb().free(eid_, instanceId);
+                dev->getInstanceIdDb().free(eid_, instanceId);
                 return;
             }
         }
@@ -455,13 +466,13 @@ void OperationSession::doOperationInit()
                 "RDE: Empty request payload is not allowed for UPDATE. EID '{EID}', targetURI '{URI}'",
                 "EID", oipInfo.eid, "URI", oipInfo.targetURI);
             updateState(OpState::OperationFailed);
-            device_->getInstanceIdDb().free(eid_, instanceId);
+            dev->getInstanceIdDb().free(eid_, instanceId);
             return;
         }
 #endif
 
         const auto& chunkMeta =
-            device_->getMetadataField("mcMaxTransferChunkSizeBytes");
+            dev->getMetadataField("mcMaxTransferChunkSizeBytes");
         const auto* maxChunkSizePtr = std::get_if<uint32_t>(&chunkMeta);
         if (!maxChunkSizePtr)
         {
@@ -469,7 +480,7 @@ void OperationSession::doOperationInit()
                 "RDE:Invalid metadata: 'mcMaxTransferChunkSizeBytes' is missing or malformed. EID={EID}",
                 "EID", eid_);
             updateState(OpState::OperationFailed);
-            device_->getInstanceIdDb().free(eid_, instanceId);
+            dev->getInstanceIdDb().free(eid_, instanceId);
             return;
         }
 
@@ -512,11 +523,11 @@ void OperationSession::doOperationInit()
               eid_, "RC", rc);
 
         updateState(OpState::OperationFailed);
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         return;
     }
 
-    rc = device_->getHandler()->registerRequest(
+    rc = dev->getHandler()->registerRequest(
         eid_, instanceId, PLDM_RDE, PLDM_RDE_OPERATION_INIT, std::move(request),
         [this](uint8_t /*eid*/, const pldm_msg* respMsg, size_t rxLen) {
             this->handleOperationInitResp(respMsg, rxLen);
@@ -531,7 +542,7 @@ void OperationSession::doOperationInit()
                     oipInfo.deviceUUID);
 #endif
         updateState(OpState::OperationFailed);
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         throw std::runtime_error("Failed to send request OperationInit");
     }
 
@@ -541,10 +552,10 @@ void OperationSession::doOperationInit()
 void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
                                                size_t rxLen)
 {
-    if (!device_)
+    auto dev = device_.lock();
+    if (!dev)
     {
-        error("RDE:handleOperationInitResp received null device pointer!");
-        return;
+        return; // Device already destroyed
     }
 
     if (currentState_ == OpState::TimedOut ||
@@ -556,7 +567,7 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
     }
 
     info("handleOperationInitResp Start: EID={EID} rxLen={RXLEN}", "EID",
-         device_->eid(), "RXLEN", rxLen);
+         dev->eid(), "RXLEN", rxLen);
 
     if (respMsg == nullptr)
     {
@@ -578,7 +589,7 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
     }
 
     const std::string& resourceIdStr =
-        device_->getRegistry()->getResourceIdFromUri(oipInfo.targetURI);
+        dev->getRegistry()->getResourceIdFromUri(oipInfo.targetURI);
     currentResourceId_ = static_cast<uint32_t>(std::stoul(resourceIdStr));
     uint8_t cc = 0;
     uint8_t operationStatus;
@@ -618,7 +629,7 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
                     oipInfo.deviceUUID);
 #endif
         updateState(OpState::OperationFailed);
-        emitTaskUpdatedSignal(device_->getBus(), oipInfo.opTaskPath, "{}",
+        emitTaskUpdatedSignal(dev->getBus(), oipInfo.opTaskPath, "{}",
                               static_cast<uint16_t>(OpState::OperationFailed));
         return;
     }
@@ -635,7 +646,7 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
             std::string decoded = getJsonStrPayload();
             info("Response{STR}", "STR", decoded.c_str());
             emitTaskUpdatedSignal(
-                device_->getBus(), oipInfo.opTaskPath, decoded.c_str(),
+                dev->getBus(), oipInfo.opTaskPath, decoded.c_str(),
                 static_cast<uint16_t>(OpState::OperationCompleted));
             doOperationComplete();
         }
@@ -644,20 +655,25 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
             try
             {
                 receiver_ = std::make_unique<pldm::rde::MultipartReceiver>(
-                    device_, eid_, resultTransferHandle);
+                    std::weak_ptr<Device>(device_), eid_, resultTransferHandle);
 
                 receiver_->start(
                     [this](std::span<const uint8_t> payload,
                            const pldm::rde::MultipartRcvMeta& meta) {
                         addChunk(currentResourceId_, payload, meta.hasChecksum,
                                  meta.isFinalChunk);
+                        auto dev = device_.lock();
+                        if (!dev)
+                        {
+                            return; // use co_return if coroutine
+                        }
                         if (isComplete())
                         {
                             info("MultipartReceive sequence completed");
                             std::string decoded = getJsonStrPayload();
                             info("Response{STR}", "STR", decoded.c_str());
                             emitTaskUpdatedSignal(
-                                device_->getBus(), oipInfo.opTaskPath,
+                                dev->getBus(), oipInfo.opTaskPath,
                                 decoded.c_str(),
                                 static_cast<uint16_t>(
                                     OpState::OperationCompleted));
@@ -701,10 +717,15 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
                     "HANDLE", resultTransferHandle, "RID", currentResourceId_);
 
                 sender_ = std::make_unique<pldm::rde::MultipartSender>(
-                    device_, eid_, payloadBuffer);
+                    std::weak_ptr<Device>(device_), eid_, payloadBuffer);
 
                 sender_->start(
                     [this](const pldm::rde::MultipartSndMeta& meta) {
+                        auto dev = device_.lock();
+                        if (!dev)
+                        {
+                            return; // use co_return if coroutine
+                        }
                         if ((meta.isOpComplete))
                         {
                             info("Multipartsend completed");
@@ -714,7 +735,7 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
                                                     oipInfo.deviceUUID);
 #endif
                             emitTaskUpdatedSignal(
-                                device_->getBus(), oipInfo.opTaskPath, "",
+                                dev->getBus(), oipInfo.opTaskPath, "",
                                 static_cast<uint16_t>(
                                     OpState::OperationCompleted));
                             doOperationComplete();
@@ -749,7 +770,7 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
             emitCacheConsumedSignal(oipInfo.opTaskPath, oipInfo.deviceUUID);
 #endif
         emitTaskUpdatedSignal(
-            device_->getBus(), oipInfo.opTaskPath, "",
+            dev->getBus(), oipInfo.opTaskPath, "",
             static_cast<uint16_t>(OpState::OperationCompleted));
         doOperationComplete();
     }
@@ -759,9 +780,15 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
 
 void OperationSession::doOperationComplete()
 {
-    auto instanceId = device_->getInstanceIdDb().next(eid_);
+    auto dev = device_.lock();
+    if (!dev)
+    {
+        return; // Device already destroyed
+    }
 
-    ResourceRegistry* resourceRegistry = device_->getRegistry();
+    auto instanceId = dev->getInstanceIdDb().next(eid_);
+
+    ResourceRegistry* resourceRegistry = dev->getRegistry();
     const std::string& resourceIdStr =
         resourceRegistry->getResourceIdFromUri(oipInfo.targetURI);
     currentResourceId_ = static_cast<uint32_t>(std::stoul(resourceIdStr));
@@ -780,11 +807,11 @@ void OperationSession::doOperationComplete()
               eid_, "RC", rc);
 
         updateState(OpState::OperationFailed);
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         return;
     }
 
-    rc = device_->getHandler()->registerRequest(
+    rc = dev->getHandler()->registerRequest(
         eid_, instanceId, PLDM_RDE, PLDM_RDE_OPERATION_COMPLETE,
         std::move(request),
         [this](uint8_t /*eid*/, const pldm_msg* respMsg, size_t rxLen) {
@@ -797,7 +824,7 @@ void OperationSession::doOperationComplete()
             "Failed to send request OperationCompelete EID '{EID}', RC '{RC}'",
             "EID", eid_, "RC", rc);
 
-        device_->getInstanceIdDb().free(eid_, instanceId);
+        dev->getInstanceIdDb().free(eid_, instanceId);
 
         throw std::runtime_error("Failed to send request OperationComplete");
     }

--- a/rde/operation_session.hpp
+++ b/rde/operation_session.hpp
@@ -48,7 +48,7 @@ class OperationSession
      * @param[in] oipInfo Metadata struct containing operation type, URI, and
      * format.
      */
-    OperationSession(std::shared_ptr<Device> device,
+    OperationSession(std::weak_ptr<Device> device,
                      struct OperationInfo oipInfo);
 
     OperationSession() = delete;
@@ -177,7 +177,7 @@ class OperationSession
                   bool hasChecksum, bool isFinalChunk);
 
   private:
-    std::shared_ptr<Device> device_;
+    std::weak_ptr<Device> device_;
     pldm::eid eid_;
     uint32_t currentResourceId_ = 0;
     OpState currentState_ = OpState::Idle;


### PR DESCRIPTION
Refresh the EID list upon rediscovery of RDE endpoint. This changeset removes the RDE endpoint data that is already existing upon rediscovery and creates a new RDE device object.