### PR TITLE
pldmd: Hertz and None sensor units

### DIFF
--- a/platform-mc/numeric_sensor.cpp
+++ b/platform-mc/numeric_sensor.cpp
@@ -105,6 +105,10 @@ void NumericSensor::setSensorUnit(uint8_t baseUnit)
     useMetricInterface = false;
     switch (baseUnit)
     {
+        case PLDM_SENSOR_UNIT_NONE:
+            sensorNameSpace = "/xyz/openbmc_project/sensors/misc/";
+            sensorUnit = SensorUnit::None;
+            break;
         case PLDM_SENSOR_UNIT_DEGRESS_C:
             sensorNameSpace = "/xyz/openbmc_project/sensors/temperature/";
             sensorUnit = SensorUnit::DegreesC;
@@ -124,6 +128,10 @@ void NumericSensor::setSensorUnit(uint8_t baseUnit)
         case PLDM_SENSOR_UNIT_WATTS:
             sensorNameSpace = "/xyz/openbmc_project/sensors/power/";
             sensorUnit = SensorUnit::Watts;
+            break;
+        case PLDM_SENSOR_UNIT_HERTZ:
+            sensorNameSpace = "/xyz/openbmc_project/sensors/frequency/";
+            sensorUnit = SensorUnit::Hertz;
             break;
         case PLDM_SENSOR_UNIT_JOULES:
             sensorNameSpace = "/xyz/openbmc_project/sensors/energy/";


### PR DESCRIPTION
For frequency (Hertz) and Just a value (None),
add sensor D-Bus object path prefix such as
 /xyz/openbmc_project/sensors/frequency/
and sensor unit value such as SensorUnit::Hertz