### PR TITLE
pldmd: Compact Numeric Sensor name

### DIFF
--- a/platform-mc/terminus.cpp
+++ b/platform-mc/terminus.cpp
@@ -530,7 +530,20 @@ std::shared_ptr<pldm_compact_numeric_sensor_pdr>
         // Handle error: input data too small to contain valid pdr
         return nullptr;
     }
-    auto parsedPdr = std::make_shared<pldm_compact_numeric_sensor_pdr>();
+
+    std::shared_ptr<pldm_compact_numeric_sensor_pdr> parsedPdr;
+
+    if (pdr->sensor_name_length > 1) {
+      size_t totalSize = offsetof(pldm_compact_numeric_sensor_pdr, sensor_name) +
+        pdr->sensor_name_length;
+      auto completeBuffer = new uint8_t[totalSize];
+
+      parsedPdr = std::shared_ptr<pldm_compact_numeric_sensor_pdr>(
+         reinterpret_cast<pldm_compact_numeric_sensor_pdr*>(completeBuffer),
+         [] (pldm_compact_numeric_sensor_pdr* p) {delete [] reinterpret_cast<uint8_t *>(p);});
+    } else {
+       parsedPdr = std::make_shared<pldm_compact_numeric_sensor_pdr>();
+    }
 
     parsedPdr->hdr = pdr->hdr;
     parsedPdr->terminus_handle = pdr->terminus_handle;
@@ -549,6 +562,12 @@ std::shared_ptr<pldm_compact_numeric_sensor_pdr>
     parsedPdr->critical_low = pdr->critical_low;
     parsedPdr->fatal_high = pdr->fatal_high;
     parsedPdr->fatal_low = pdr->fatal_low;
+
+    if (pdr->sensor_name_length > 0) {
+     std::copy(pdr->sensor_name, pdr->sensor_name + pdr->sensor_name_length,
+       parsedPdr->sensor_name);
+    }
+
     return parsedPdr;
 }
 


### PR DESCRIPTION
For a Compact Numeric Sensor, when sensorNameString is assigned along with sensorNameStringByteLength, allocate the buffer large enough to copy sensorNameString to the parsed pdr, along with the rest of the fields of
the Compact Numeric Sensor.
Since 96 bytes is recommended and not mandated, not checking for the maximum of 96 bytes of buffer.