### PR TITLE
pldmd: pldmtool: SFS error completion code

### DIFF
--- a/pldmtool/oem/amd/pldm_oem_amd.cpp
+++ b/pldmtool/oem/amd/pldm_oem_amd.cpp
@@ -284,7 +284,9 @@ void AmdMctpSfsOp::handleSFSResponse(const uint8_t* msg, size_t size)
     if (msg[COMP_CODE_BYTE] != 0)
     {
         std::cerr << "Command failed with completion code: "
-                  << msg[COMP_CODE_BYTE] << std::endl;
+                  << std::showbase << std::hex
+                  << static_cast<int>(msg[COMP_CODE_BYTE]) << std::dec
+                  << std::endl;
         return;
     }
 


### PR DESCRIPTION
Fix printing completion code by pldmtool in case
of an error completion code is returned in a
respone by SFS during such commands as
 pldmtool amdMctpSfs

Instead of printing a blank error code,
 Command failed with completion code:
print it correctly such as
 Command failed with completion code: 0x4
 Command failed with completion code: 0x12