### PR TITLE
pldm: Limit polling to sensors without effecters

### DIFF
--- a/platform-mc/sensor_manager.cpp
+++ b/platform-mc/sensor_manager.cpp
@@ -249,7 +249,11 @@ exec::task<int> SensorManager::doSensorPollingTask(pldm_tid_t tid)
 
             sd_event_now(event.get(), CLOCK_MONOTONIC, &t1);
             elapsed = t1 - sensor->timeStamp;
+#ifdef OEM_AMD
+            if (sensor->updateTime != 0 && ((sensor->updateTime <= elapsed) || (!sensor->timeStamp)))
+#else
             if ((sensor->updateTime <= elapsed) || (!sensor->timeStamp))
+#endif
             {
                 rc = co_await getSensorReading(sensor);
 

--- a/platform-mc/terminus.cpp
+++ b/platform-mc/terminus.cpp
@@ -283,6 +283,23 @@ void Terminus::parseTerminusPDRs()
     addNextSensorFromPDRs();
 }
 
+#ifdef OEM_AMD
+void Terminus::updateSensorPollRates() {
+    for (auto& sensor : numericSensors) {
+        auto it = std::find_if(numericEffecters.begin(), numericEffecters.end(),
+            [&sensor](const auto& effecter) {
+                return effecter->effecterId == sensor->sensorId;
+            });
+
+        if (it != numericEffecters.end()) {
+            lg2::info("Match found: Sensor {ID} has corresponding Effecter. Disabling polling.",
+                     "ID", sensor->sensorId);
+            sensor->updateTime = 0;
+        }
+    }
+}
+#endif
+
 void Terminus::addNextSensorFromPDRs()
 {
     sensorCreationEvent.reset();
@@ -361,6 +378,9 @@ void Terminus::addNextEffecterFromPDRs()
         lg2::info(
             "Terminus ID {TID}: Completed creating effecters. Total effecters: {NEFFECTERS}",
             "TID", tid, "NEFFECTERS", numericEffecters.size());
+#ifdef OEM_AMD
+        updateSensorPollRates();
+#endif
     }
 }
 
@@ -727,7 +747,6 @@ void Terminus::addNumericEffecter(
 
         auto effecter = std::make_shared<NumericEffecter>(
             tid, pdr, effecterName, inventoryPath, *this, terminusManager, terminusScope);
-        lg2::info("Created NumericEffecter {NAME}", "NAME", effecterName);
         numericEffecters.emplace_back(effecter);
     }
     catch (const std::exception& e)

--- a/platform-mc/terminus.hpp
+++ b/platform-mc/terminus.hpp
@@ -442,6 +442,19 @@ class Terminus
      */
     std::vector<std::string> getEffecterNames(const pldm::platform_mc::EffecterID& effecterId);
 
+#ifdef OEM_AMD
+    /** @brief Updates the polling rates for numeric sensors.
+     *
+     *  This function iterates through all numeric sensors and checks if a
+     *  corresponding numeric effecter exists with the same ID. If a match
+     *  is found, polling is disabled for that sensor to prevent redundant
+     *  operations or conflicts.
+     *
+     *  @return None
+     */
+    void updateSensorPollRates();
+#endif
+
     /** @brief Add the next sensor PDR to this terminus, iterated by
      *         sensorPdrIt.
      */


### PR DESCRIPTION
Separate out polling for Out-Of-Band (OOB)
platform event from sensor polling.
Since sensor polling has been disabled for now, we need a way to handle OOB platform events.