### PR TITLE
pldm: Enable verbose mode for OOB event

### DIFF
--- a/platform-mc/event_manager.cpp
+++ b/platform-mc/event_manager.cpp
@@ -19,6 +19,84 @@ namespace platform_mc
 {
 namespace fs = std::filesystem;
 
+void EventManager::logPldmErrorEvent(
+    pldm_tid_t tid, uint16_t eventId, uint8_t eventClass,
+    const uint8_t* eventData, size_t eventDataSize)
+{
+    fs::path dir{"/tmp/pldm_event_log"};
+    fs::path filePath{"<unknown>"};
+
+    try
+    {
+        // Ensure directory exists (safe even if already exists)
+        fs::create_directories(dir);
+
+        // Epoch timestamp (seconds)
+        auto now = std::chrono::system_clock::now();
+        auto epoch =
+            std::chrono::duration_cast<std::chrono::seconds>(
+                now.time_since_epoch())
+                .count();
+
+        static std::atomic<uint32_t> counter{0};
+
+        // Build filename with hex fields
+        std::ostringstream filename;
+        filename << "pldm_oob_err_" << epoch
+                 << "_" << counter++
+                 << "_ec0x" << std::hex << std::setw(2) << std::setfill('0')
+                 << static_cast<int>(eventClass)
+                 << "_tid0x" << std::setw(2)
+                 << static_cast<int>(tid)
+                 << "_eventid0x" << std::setw(4)
+                 << eventId
+                 << ".bin";
+
+        filePath = dir / filename.str();
+
+        // Open file
+        std::ofstream ofs(filePath, std::ios::binary);
+        if (!ofs)
+        {
+            lg2::error(
+                "Failed to open PLDM event file. PATH={PATH} ERRNO={ERRNO} ERRMSG={ERRMSG}",
+                "PATH", filePath.string(),
+                "ERRNO", errno,
+                "ERRMSG", std::strerror(errno));
+
+            return;
+        }
+
+        // Write raw event data
+        ofs.write(reinterpret_cast<const char*>(eventData),
+                  eventDataSize);
+
+        if (!ofs)
+        {
+            lg2::error(
+                "Failed to write PLDM event data. PATH={PATH}",
+                "PATH", filePath.string());
+            return;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error(
+            "Exception writing PLDM event file. PATH={PATH} ERROR={ERROR}",
+            "PATH", filePath.string(),
+            "ERROR", e.what());
+        return;
+    }
+
+    // Use debug to avoid log flooding in production
+    lg2::debug(
+        "PLDM event file created. PATH={PATH} TID={TID} EVENTID={EVID} EVENTCLASS={EVCLASS}",
+        "PATH", filePath.string(),
+        "TID", static_cast<uint32_t>(tid),
+        "EVID", lg2::hex, static_cast<uint32_t>(eventId),
+        "EVCLASS", lg2::hex, static_cast<uint32_t>(eventClass));
+}
+
 int EventManager::handlePlatformEvent(
     pldm_tid_t tid, uint16_t eventId, uint8_t eventClass,
     const uint8_t* eventData, size_t eventDataSize)
@@ -99,6 +177,9 @@ int EventManager::handlePlatformEvent(
         auto it = termini.find(tid);
         if (it != termini.end())
         {
+            if (eventId != PLDM_PLATFORM_EVENT_ID_NULL && verbose)
+               logPldmErrorEvent(tid, eventId, eventClass, eventData, eventDataSize);
+
             auto& terminus = it->second; // Reference for clarity
             terminus->pollEvent = true;
             terminus->pollEventId = poll_event.event_id;

--- a/platform-mc/event_manager.hpp
+++ b/platform-mc/event_manager.hpp
@@ -40,7 +40,7 @@ class EventManager
     virtual ~EventManager() = default;
 
     explicit EventManager(TerminusManager& terminusManager,
-                          TerminiMapper& termini) :
+                          TerminiMapper& termini, const bool verbose) :
         terminusManager(terminusManager), termini(termini)
     {
         // Default response handler for PollForPlatFormEventMessage
@@ -59,6 +59,7 @@ class EventManager
                 return this->handlePlatformEvent(tid, eventId, PLDM_CPER_EVENT,
                                                  eventData, eventDataSize);
             }});
+        this->verbose = verbose;
     };
 
     /** @brief Handle platform event
@@ -220,6 +221,24 @@ class EventManager
                                  uint16_t eventId,
                                  std::vector<uint8_t>& eventMessage);
 
+    /** @brief Logs a PLDM error event to a binary file in the local filesystem.
+     *
+     *  This function creates a binary file containing the raw event data for
+     *  out-of-band error analysis. Files are stored in /tmp/pldm_event_log with
+     *  filenames capturing the timestamp, event class, TID, and event ID.
+     *
+     *  @param[in] tid - Terminus ID that generated the event
+     *  @param[in] eventId - The specific PLDM event identifier
+     *  @param[in] eventClass - The class of the PLDM event (e.g., sensor, task)
+     *  @param[in] eventData - Pointer to the raw binary event data payload
+     *  @param[in] eventDataSize - Size of the event data payload in bytes
+     *
+     *  @return None
+     */
+    void logPldmErrorEvent(
+        pldm_tid_t tid, uint16_t eventId, uint8_t eventClass,
+        const uint8_t* eventData, size_t eventDataSize);
+
     /** @brief Reference of terminusManager */
     TerminusManager& terminusManager;
 
@@ -231,6 +250,8 @@ class EventManager
 
     /** @brief map of PLDM event type of polled event to EventHandlers */
     pldm::platform_mc::EventMap eventHandlers;
+
+    bool verbose{false};
 };
 } // namespace platform_mc
 } // namespace pldm

--- a/platform-mc/manager.hpp
+++ b/platform-mc/manager.hpp
@@ -36,13 +36,13 @@ class Manager : public pldm::MctpDiscoveryHandlerIntf
     ~Manager() = default;
 
     explicit Manager(sdeventplus::Event& event, RequesterHandler& handler,
-                     pldm::InstanceIdDb& instanceIdDb) :
+                     pldm::InstanceIdDb& instanceIdDb, const bool verbose) :
         terminusManager(event, handler, instanceIdDb, termini, this,
                         pldm::BmcMctpEid),
         platformManager(terminusManager, termini, this),
         sensorManager(event, terminusManager, termini, this),
-        eventManager(terminusManager, termini)
-    {}
+        eventManager(terminusManager, termini, verbose)
+    {this->verbose = verbose;}
 
     /** @brief Helper function to do the actions before discovering terminus
      *
@@ -287,6 +287,8 @@ class Manager : public pldm::MctpDiscoveryHandlerIntf
 
     /** @brief map of PLDM event type to EventHandlers */
     PollHandlers pollHandlers;
+
+    bool verbose{false};
 };
 } // namespace platform_mc
 } // namespace pldm

--- a/pldmd/pldmd.cpp
+++ b/pldmd/pldmd.cpp
@@ -220,7 +220,7 @@ int main(int argc, char** argv)
     DBusHandler dbusHandler;
 
     std::unique_ptr<platform_mc::Manager> platformManager =
-        std::make_unique<platform_mc::Manager>(event, reqHandler, instanceIdDb);
+        std::make_unique<platform_mc::Manager>(event, reqHandler, instanceIdDb, verbose);
 
 #ifdef LIBPLDMRESPONDER
     using namespace pldm::state_sensor;


### PR DESCRIPTION
Only when pldmd runs with verbose option i.e. pldmd -vvv, during OOB platform error event handling, generate a file under /tmp with the contents of the error event data.