### PR TITLE
Revert "pldmd: Disable numeric sensor polling"

### DIFF
--- a/platform-mc/manager.hpp
+++ b/platform-mc/manager.hpp
@@ -106,10 +106,7 @@ class Manager : public pldm::MctpDiscoveryHandlerIntf
      */
     void startSensorPolling(pldm_tid_t tid)
     {
-        std::cerr << "Disable polling for pldm sensors for now" << tid << std::endl;
-
-        return;
-        // sensorManager.startPolling(tid);
+        sensorManager.startPolling(tid);
     }
 
     /** @brief Helper function to set available state for pldm request (sensor


### PR DESCRIPTION
This reverts commit 0b5226e303f4605e87bf96e964704691b8bb3e9e.