### PR TITLE
pldm: Handle 64 bit sensorDatasize

### DIFF
--- a/platform-mc/sensor_manager.cpp
+++ b/platform-mc/sensor_manager.cpp
@@ -408,6 +408,12 @@ exec::task<int> SensorManager::getSensorReading(
         case PLDM_SENSOR_DATA_SIZE_SINT32:
             value = static_cast<double>(presentReading.value_s32);
             break;
+        case PLDM_SENSOR_DATA_SIZE_UINT64:
+            value = static_cast<double>(presentReading.value_u64);
+            break;
+        case PLDM_SENSOR_DATA_SIZE_SINT64:
+            value = static_cast<double>(presentReading.value_s64);
+            break;
         default:
             value = std::numeric_limits<double>::quiet_NaN();
             break;


### PR DESCRIPTION
Handle uint64 and sint64 sensorDataSize as part of the response to command getSensorReading of a PLDM sensor.