### PR TITLE
rde: Cache the APCB Token data

### DIFF
--- a/oem/amd/rde/cache_manager_dbus.hpp
+++ b/oem/amd/rde/cache_manager_dbus.hpp
@@ -5,21 +5,34 @@
 #include <sdbusplus/server/object.hpp>
 #include <xyz/openbmc_project/RDE/CacheManager/server.hpp>
 
-#include <vector>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <string>
+#include <variant>
+#include <vector>
+
+PHOSPHOR_LOG2_USING;
 
 namespace pldm::rde
 {
 
 using CacheManagerIface = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::RDE::server::CacheManager>;
+using APCBValue = std::variant<int64_t, std::string>;
+using APCBEntry = std::map<std::string, APCBValue>;
+using APCBDataTableType = std::map<std::string, APCBEntry>;
 
 class CacheManagerObject : public CacheManagerIface
 {
   public:
     CacheManagerObject(sdbusplus::bus_t& bus, const char* path) :
         CacheManagerIface(bus, path)
-    {}
+    {
+        loadAPCBDataTableFromDisk();
+    }
 
     /**
      * @brief Implementation for GetCurrentCache
@@ -29,6 +42,57 @@ class CacheManagerObject : public CacheManagerIface
      * @return Operations - List of cached operations as JSON strings.
      */
     std::vector<std::string> getCurrentCache(std::string uuid) override;
+
+    void updateAPCBDataTable(const std::string& uuid,
+                             const nlohmann::json& parsedPayload)
+    {
+        auto table = this->apcbDataTable();
+        table[uuid] = jsonToAPCBEntry(parsedPayload);
+
+        this->apcbDataTable(table);
+        persistAPCBDataTableToDisk(table);
+    }
+
+    static nlohmann::json apcbEntryToJson(const APCBEntry& entry)
+    {
+        nlohmann::json payload = nlohmann::json::object();
+        for (const auto& [key, value] : entry)
+        {
+            std::visit(
+                [&](const auto& v) { payload[key] = v; }, value);
+        }
+        return payload;
+    }
+
+    void loadAPCBDataTableFromDisk()
+    {
+        std::ifstream inFile(apcbPersistFile);
+        if (!inFile.is_open())
+        {
+            info("RDE: APCB persistence file does not exist yet: {FILE}",
+                 "FILE", apcbPersistFile);
+            this->apcbDataTable(APCBDataTableType{});
+            return;
+        }
+
+        try
+        {
+            nlohmann::json j = nlohmann::json::object();
+            inFile >> j;
+
+            APCBDataTableType table = jsonToAPCBDataTable(j);
+            this->apcbDataTable(table);
+
+            info("RDE: Restored APCBDataTable from {FILE}",
+                 "FILE", apcbPersistFile);
+        }
+        catch (const std::exception& e)
+        {
+            error("RDE: Failed to restore APCBDataTable from {FILE}: {ERR}",
+                  "FILE", apcbPersistFile, "ERR", e.what());
+            this->apcbDataTable(APCBDataTableType{});
+        }
+    }
 
     /**
      * @brief Implementation for CreateCache
@@ -54,6 +118,120 @@ class CacheManagerObject : public CacheManagerIface
         sdbusplus::xyz::openbmc_project::RDE::server::Manager::EncodingFormatType
             encodingFormat,
         std::string sessionId) override;
+
+  private:
+    static constexpr const char* apcbPersistFile =
+        "/var/lib/pldm/apcb_data_table.json";
+
+    bool persistAPCBDataTableToDisk(const APCBDataTableType& table)
+    {
+        try
+        {
+            std::filesystem::create_directories("/var/lib/pldm");
+
+            std::ofstream outFile(apcbPersistFile);
+            if (!outFile.is_open())
+            {
+                error("RDE: Failed to open APCB persistence file {FILE}",
+                      "FILE", apcbPersistFile);
+                return false;
+            }
+
+            nlohmann::json j = apcbDataTableToJson(table);
+            outFile << j.dump(4) << std::endl;
+
+            info("RDE: Persisted APCBDataTable to {FILE}",
+                 "FILE", apcbPersistFile);
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            error("RDE: Failed to persist APCBDataTable: {ERR}",
+                  "ERR", e.what());
+            return false;
+        }
+    }
+
+    static APCBEntry jsonToAPCBEntry(const nlohmann::json& j)
+    {
+        APCBEntry entry;
+
+        if (!j.is_object())
+        {
+            throw std::runtime_error("APCB JSON payload is not an object");
+        }
+
+        for (const auto& [key, value] : j.items())
+        {
+            if (value.is_number_integer())
+            {
+                entry[key] = value.get<int64_t>();
+            }
+            else if (value.is_string())
+            {
+                entry[key] = value.get<std::string>();
+            }
+            else if (value.is_number_unsigned())
+            {
+                entry[key] = static_cast<int64_t>(value.get<uint64_t>());
+            }
+            else if (value.is_boolean())
+            {
+                entry[key] = value.get<bool>() ? "true" : "false";
+            }
+            else if (value.is_number_float())
+            {
+                entry[key] = std::to_string(value.get<double>());
+            }
+            else
+            {
+                entry[key] = value.dump();
+            }
+        }
+
+        return entry;
+    }
+
+    static APCBDataTableType jsonToAPCBDataTable(const nlohmann::json& j)
+    {
+        APCBDataTableType table;
+
+        if (!j.is_object())
+        {
+            throw std::runtime_error("Persisted APCB table JSON is not an object");
+        }
+
+        for (const auto& [uuid, value] : j.items())
+        {
+            table[uuid] = jsonToAPCBEntry(value);
+        }
+
+        return table;
+    }
+
+    static nlohmann::json apcbDataTableToJson(const APCBDataTableType& table)
+    {
+        nlohmann::json j = nlohmann::json::object();
+
+        for (const auto& [uuid, entry] : table)
+        {
+            nlohmann::json je = nlohmann::json::object();
+
+            for (const auto& [key, value] : entry)
+            {
+                std::visit(
+                    [&](const auto& v)
+                    {
+                        je[key] = v;
+                    },
+                    value);
+            }
+
+            j[uuid] = je;
+        }
+
+        return j;
+    }
 };
 
 } // namespace pldm::rde

--- a/rde/device.cpp
+++ b/rde/device.cpp
@@ -1,7 +1,14 @@
 #include "device.hpp"
 
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <unordered_map>
+
 #ifdef OEM_AMD
+#include "cache_manager_dbus.hpp"
 #include "manager.hpp"
+#include "operation_task.hpp"
 #include "rde_cache_manager.hpp"
 #include "utils.hpp"
 
@@ -34,6 +41,13 @@ Device::~Device()
 {
     info("RDE : D-Bus Device object destroyed UUID:{UUID} EID:{EID}", "UUID",
          deviceUUID(), "EID", static_cast<int>(eid()));
+
+#ifdef OEM_AMD
+    biosGetTaskUpdatedMatch_.reset();
+    taskUpdatedMatch_.reset();
+    cacheManager_ = nullptr;
+    manager_ = nullptr;
+#endif
 }
 
 void Device::refreshDeviceInfo()
@@ -156,6 +170,70 @@ bool Device::shouldDeferOperation(const OperationInfo& oipInfo)
     return false;
 }
 
+bool Device::getAPCBTokenCache(
+    const OperationInfo& opInfo)
+{
+    if (opInfo.operationType != OperationType::READ ||
+        opInfo.targetURI != SocConfigurationTokenURI)
+    {
+        return false;
+    }
+
+    if (!cacheManager_)
+    {
+        error("RDE: cacheManager_ is null, cannot serve Token GET from APCB");
+        return false;
+    }
+
+    const APCBDataTableType table = cacheManager_->apcbDataTable();
+    auto entryIt = table.find(deviceUUID());
+    if (entryIt == table.end() || entryIt->second.empty())
+    {
+        info(
+            "RDE: No APCBDataTable entry for UUID={UUID}, cannot serve cached Token GET",
+            "UUID", deviceUUID());
+        return false;
+    }
+
+    const std::string payload =
+        CacheManagerObject::apcbEntryToJson(entryIt->second).dump();
+
+    std::weak_ptr<Device> weakSelf = weak_from_this();
+    const std::string taskPath = opInfo.opTaskPath;
+    const uint32_t operationID = opInfo.operationID;
+
+    deferredApcbTaskSignal_ = std::make_unique<sdeventplus::source::Defer>(
+        event_, [weakSelf, taskPath, operationID,
+                 payload](sdeventplus::source::EventBase&) mutable {
+            auto self = weakSelf.lock();
+            if (!self)
+            {
+                return;
+            }
+            self->deferredApcbTaskSignal_.reset();
+
+            const int signalRc = emitTaskUpdatedSignal(
+                self->bus_, taskPath, payload,
+                static_cast<uint16_t>(OpState::OperationCompleted));
+            if (signalRc != PLDM_SUCCESS)
+            {
+                error(
+                    "RDE: Failed to emit deferred cached Token GET TaskUpdated for OID={OID}",
+                    "OID", operationID);
+                return;
+            }
+
+            info(
+                "RDE: Served SocConfiguration Token GET from APCBDataTable (deferred), UUID={UUID}, OID={OID}",
+                "UUID", self->deviceUUID(), "OID", operationID);
+        });
+
+    info(
+        "RDE: Scheduling APCBDataTable Token GET response for UUID={UUID}, OID={OID}",
+        "UUID", deviceUUID(), "OID", opInfo.operationID);
+    return true;
+}
+
 bool Device::isReplayOperation(const OperationInfo& opInfo) const
 {
     return (currentReplayOperationId_ != 0 &&
@@ -170,6 +248,12 @@ bool Device::canCacheOperation(const OperationInfo& opInfo) const
         info(
             "RDE Cache: Device UUID={UUID} not found in rde_device_metadata.json, skipping cache",
             "UUID", opInfo.deviceUUID);
+        return false;
+    }
+
+    if (opInfo.operationType == OperationType::READ &&
+        opInfo.targetURI == SocConfigurationTokenURI)
+    {
         return false;
     }
 
@@ -230,7 +314,7 @@ void Device::replayCachedOperations()
                     "xyz.openbmc_project.RDE.OperationTask"),
             [weakSelf](sdbusplus::message::message& msg) {
                 auto self = weakSelf.lock();
-                if (!self)
+                if (!self || self->shuttingDown_)
                 {
                     return;
                 }
@@ -329,7 +413,7 @@ void Device::processNextCachedOperation()
         currentReplayOperationId_ = 0;
         currentReplayTimestamp_ = 0;
         isReplayInProgress_ = false;
-        sendBiosZeroLengthCommand();
+        sendBiosGetCommand();
         return;
     }
 
@@ -391,6 +475,338 @@ void Device::stopReplay()
     currentReplayOperationId_ = 0;
     currentReplayTimestamp_ = 0;
     isReplayInProgress_ = false;
+}
+
+inline bool writeJsonToFile(const nlohmann::json& jsonData,
+                            const std::string& filePath)
+{
+    try
+    {
+        std::ofstream outFile(filePath);
+        if (!outFile.is_open())
+        {
+            error("RDE: Failed to open file {FILE}", "FILE", filePath);
+            return false;
+        }
+
+        outFile << jsonData.dump(4) << std::endl;
+        outFile.close();
+
+        info("RDE: Successfully wrote JSON to file {FILE}", "FILE", filePath);
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        error("RDE: Exception while writing JSON to file {FILE}: {ERR}",
+              "FILE", filePath, "ERR", e.what());
+        return false;
+    }
+}
+
+inline nlohmann::json handleDeferredBindings(const std::string& bejJsonInput,
+                                             const nlohmann::json& uriMapJson)
+{
+    std::unordered_map<int, std::string> uriMap;
+    for (const auto& [key, value] : uriMapJson.items())
+    {
+        try
+        {
+            int resourceId = std::stoi(key);
+            uriMap[resourceId] = value.get<std::string>();
+        }
+        catch (const std::exception& e)
+        {
+            error(
+                "RDE: Invalid resource ID in uriMapJson: Key={KEY} error={ERR}",
+                "KEY", key, "ERR", e.what());
+        }
+    }
+
+    std::string bejJson = bejJsonInput;
+    std::regex bareObjectRegex("\\{\\s*\"%L(\\d+)\"\\s*\\}");
+    std::ostringstream oss1;
+    std::sregex_iterator begin1(bejJson.begin(), bejJson.end(),
+                                bareObjectRegex);
+    std::sregex_iterator end1;
+    size_t lastPos1 = 0;
+
+    for (auto it = begin1; it != end1; ++it)
+    {
+        oss1 << bejJson.substr(
+            lastPos1,
+            static_cast<size_t>(static_cast<std::ptrdiff_t>(it->position()) -
+                                static_cast<std::ptrdiff_t>(lastPos1)));
+
+        int id = std::stoi((*it)[1]);
+        auto uriIt = uriMap.find(id);
+        if (uriIt != uriMap.end())
+        {
+            oss1 << R"({"@odata.id":")" << uriIt->second << R"("})";
+        }
+        else
+        {
+            oss1 << it->str();
+        }
+        lastPos1 = static_cast<size_t>(it->position() + it->length());
+    }
+    oss1 << bejJson.substr(lastPos1);
+    bejJson = oss1.str();
+
+    std::regex lPattern(R"(%L(\d+))");
+    std::ostringstream oss2;
+    std::sregex_iterator begin2(bejJson.begin(), bejJson.end(), lPattern);
+    std::sregex_iterator end2;
+    size_t lastPos2 = 0;
+
+    for (auto it = begin2; it != end2; ++it)
+    {
+        oss2 << bejJson.substr(
+            lastPos2,
+            static_cast<size_t>(static_cast<std::ptrdiff_t>(it->position()) -
+                                static_cast<std::ptrdiff_t>(lastPos2)));
+
+        int id = std::stoi((*it)[1]);
+        auto uriIt = uriMap.find(id);
+        if (uriIt != uriMap.end())
+        {
+            oss2 << uriIt->second;
+        }
+        else
+        {
+            oss2 << it->str();
+        }
+        lastPos2 = static_cast<size_t>(it->position() + it->length());
+    }
+    oss2 << bejJson.substr(lastPos2);
+    bejJson = oss2.str();
+
+    bejJson = std::regex_replace(bejJson, std::regex(R"(%I(\d+))"), "$1");
+
+    nlohmann::json jsonPayload;
+    if (!bejJson.empty())
+    {
+        jsonPayload = nlohmann::json::parse(bejJson);
+    }
+    return jsonPayload;
+}
+
+void Device::handleBiosGetTaskSignal(
+    sdbusplus::message::message& msg,
+    uint32_t operationID,
+    std::shared_ptr<std::string> payloadBuffer)
+{
+    if (shuttingDown_)
+    {
+        return;
+    }
+
+    std::map<std::string, std::variant<std::string, uint16_t>> changed;
+
+    try
+    {
+        msg.read(changed);
+    }
+    catch (const std::exception& e)
+    {
+        error("RDE BIOS GET: Failed to read signal: {MSG}", "MSG",
+              e.what());
+        return;
+    }
+
+    std::optional<uint16_t> completionCode;
+
+    if (auto it = changed.find("CompletionCode"); it != changed.end())
+    {
+        if (auto val = std::get_if<uint16_t>(&it->second))
+        {
+            completionCode = *val;
+        }
+    }
+    if (!completionCode)
+    {
+        if (auto it = changed.find("return_code"); it != changed.end())
+        {
+            if (auto val = std::get_if<uint16_t>(&it->second))
+            {
+                completionCode = *val;
+            }
+        }
+    }
+
+    if (auto it = changed.find("payload"); it != changed.end())
+    {
+        if (auto val = std::get_if<std::string>(&it->second))
+        {
+            *payloadBuffer = *val;
+
+            info("RDE BIOS GET: Payload update len={LEN} OID={OID}",
+                 "LEN", payloadBuffer->size(), "OID", operationID);
+        }
+    }
+
+    if (!completionCode)
+    {
+        return;
+    }
+
+    if (*completionCode == 7)
+    {
+        info("RDE BIOS GET: Completed OID={OID}", "OID", operationID);
+
+        if (payloadBuffer->empty())
+        {
+            error("RDE BIOS GET: Completed but payload empty OID={OID}",
+                  "OID", operationID);
+        }
+        else
+        {
+            try
+            {
+                nlohmann::json uriMapJson = nlohmann::json::object();
+
+                if (!resourceRegistry_)
+                {
+                    error("RDE BIOS GET: resourceRegistry_ is null");
+                }
+                else
+                {
+                    const auto& resourceMap =
+                        resourceRegistry_->getResourceMap();
+
+                    for (const auto& [resourceId, info] : resourceMap)
+                    {
+                       uriMapJson[resourceId] = info.uri;
+                    }
+                }
+
+                auto parsedPayload =
+                    handleDeferredBindings(*payloadBuffer, uriMapJson);
+
+                if (!cacheManager_)
+                {
+                    error(
+                        "RDE BIOS GET: cacheManager_ is null, cannot update APCBDataTable");
+                }
+                else
+                {
+                    cacheManager_->updateAPCBDataTable(deviceUUID(),
+                                                       parsedPayload);
+                    info("RDE BIOS GET: APCBDataTable updated for UUID={UUID}",
+                         "UUID", deviceUUID());
+                }
+            }
+            catch (const std::exception& e)
+            {
+                error("RDE BIOS GET: Payload processing failed: {MSG}",
+                      "MSG", e.what());
+            }
+        }
+
+        biosGetTaskUpdatedMatch_.reset();
+
+        sendBiosZeroLengthCommand();
+
+        return;
+    }
+
+    info("RDE BIOS GET: Interim update OID={OID}, code={CODE}",
+         "OID", operationID, "CODE", *completionCode);
+}
+
+void Device::sendBiosGetCommand()
+{
+    std::string processorURI = loadProcessorURI(deviceUUID());
+    auto payloadBuffer = std::make_shared<std::string>();
+
+    if (processorURI.empty())
+    {
+        info(
+            "RDE Cache Replay: Device UUID={UUID} not found in rde_device_metadata.json, skipping BIOS zero length command",
+            "UUID", deviceUUID());
+        return;
+    }
+
+    if (!manager_)
+    {
+        error(
+            "RDE Cache Replay: Manager not set, cannot send BIOS get command for UUID={UUID}",
+            "UUID", deviceUUID());
+        return;
+    }
+
+    try
+    {
+        uint32_t operationID = manager_->getNextAvailableOperationId();
+        if (operationID == 0)
+        {
+            error(
+                "RDE Cache Replay: Failed to generate operation ID for BIOS get command, UUID={UUID}",
+                "UUID", deviceUUID());
+            return;
+        }
+
+        OperationType operationType = OperationType::READ;
+        std::string subURI = SocConfigurationTokenURI;
+        std::string payload = "";
+        PayloadFormatType payloadFormat = PayloadFormatType::Inline;
+        EncodingFormatType encodingType = EncodingFormatType::JSON;
+        std::string sessionID = manager_->getJSONSchema();
+        if (sessionID.empty())
+        {
+            error(
+                "RDE Cache Replay: Cannot find session ID for BIOS zero length command, UUID={UUID}",
+                "UUID", deviceUUID());
+            return;
+        }
+
+        std::string taskPathStr = "/xyz/openbmc_project/RDE/OperationTask/" +
+                                  std::to_string(operationID);
+
+        OperationInfo opInfo{operationID,   operationType, subURI,
+                             deviceUUID(),  eid(),         payload,
+                             payloadFormat, encodingType,  sessionID,
+                             taskPathStr};
+
+        auto task = std::make_shared<OperationTask>(bus_, opInfo.opTaskPath);
+        manager_->registerOperationTask(operationID, task);
+
+
+        std::weak_ptr<Device> weakSelf = shared_from_this();
+
+        biosGetTaskUpdatedMatch_ = std::make_unique<sdbusplus::bus::match_t>(
+                bus_, rdeOpTaskMatch(taskPathStr),
+                [weakSelf, operationID, payloadBuffer](sdbusplus::message::message& msg) {
+            auto self = weakSelf.lock();
+            if (!self)
+            {
+                return;
+            }
+
+            self->handleBiosGetTaskSignal(msg, operationID, payloadBuffer);
+        });
+
+        std::shared_ptr<Device> self = shared_from_this();
+        opSession_ = std::make_unique<OperationSession>(self, opInfo);
+        if (!opSession_)
+        {
+            error(
+                "RDE Cache Replay: Failed to create OperationSession for BIOS GET command, UUID={UUID}",
+                "UUID", deviceUUID());
+
+            return;
+        }
+
+        info(
+            "RDE Cache Replay: Sending BIOS GET command for UUID={UUID}, OperationID={OID}",
+            "UUID", deviceUUID(), "OID", operationID);
+        opSession_->doOperationInit();
+    }
+    catch (const std::exception& e)
+    {
+        error(
+            "RDE Cache Replay: Failed to send BIOS GET command for UUID={UUID}: {MSG}",
+           "UUID", deviceUUID(), "MSG", e.what());
+    }
 }
 
 void Device::sendBiosZeroLengthCommand()
@@ -476,6 +892,11 @@ void Device::sendBiosZeroLengthCommand()
 void Device::setManager(Manager* manager)
 {
     manager_ = manager;
+}
+
+void Device::setCacheManager(CacheManagerObject* manager)
+{
+    cacheManager_ = manager;
 }
 #endif
 
@@ -590,6 +1011,14 @@ void Device::updateState(DeviceState newState)
 void Device::shutdown()
 {
     shuttingDown_ = true;
+
+#ifdef OEM_AMD
+    biosGetTaskUpdatedMatch_.reset();
+    taskUpdatedMatch_.reset();
+    stopReplay();
+    cacheManager_ = nullptr;
+    manager_ = nullptr;
+#endif
 
     if (opSession_)
         opSession_.reset();

--- a/rde/device.hpp
+++ b/rde/device.hpp
@@ -12,6 +12,7 @@
 #ifdef OEM_AMD
 #include "operation_task.hpp"
 #include "rde_cache_manager.hpp"
+#include "cache_manager_dbus.hpp"
 #endif
 
 #include <libpldm/base.h>
@@ -31,6 +32,8 @@
 #include <tuple>
 #include <variant>
 #include <vector>
+#include <sdbusplus/bus/match.hpp>
+#include <sdbusplus/message.hpp>
 
 namespace pldm::rde
 {
@@ -42,6 +45,22 @@ using SchemaResourcesType = std::map<std::string, PropertyMap>;
 using EntryIfaces = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::RDE::server::Device,
     sdbusplus::xyz::openbmc_project::Common::server::UUID>;
+
+#ifdef OEM_AMD
+inline constexpr const char* rdePldmService = "xyz.openbmc_project.PLDM";
+inline constexpr const char* rdeOperationTaskInterface =
+    "xyz.openbmc_project.RDE.OperationTask";
+inline constexpr const char* rdeTaskUpdatedMember = "TaskUpdated";
+
+/** @brief D-Bus match rule for OperationTask TaskUpdated on @p objPath. */
+inline std::string rdeOpTaskMatch(const std::string& objPath)
+{
+    return "type='signal',sender='" + std::string(rdePldmService) +
+           "',interface='" + std::string(rdeOperationTaskInterface) +
+           "',member='" + std::string(rdeTaskUpdatedMember) + "',path='" + objPath +
+           "'";
+}
+#endif
 
 /**
  * @class Device
@@ -153,6 +172,7 @@ class Device : public EntryIfaces, public std::enable_shared_from_this<Device>
      */
     void setManager(Manager* manager);
 
+    void setCacheManager(CacheManagerObject* manager);
     /**
      * @brief Stop cache replay and reset all replay state
      *
@@ -170,6 +190,15 @@ class Device : public EntryIfaces, public std::enable_shared_from_this<Device>
      * Only sends if the device UUID is found in rde_device_metadata.json.
      */
     void sendBiosZeroLengthCommand();
+
+    void sendBiosGetCommand();
+
+    /**
+     * @brief Complete Token READ from APCBDataTable via TaskUpdated (no host PLDM).
+     * @return true if cached APCB data was emitted for this operation.
+     */
+    bool getAPCBTokenCache(const OperationInfo& opInfo);
+
 #endif
 
     /**
@@ -333,6 +362,11 @@ class Device : public EntryIfaces, public std::enable_shared_from_this<Device>
     std::unique_ptr<DiscoverySession> discovSession_;
     std::unique_ptr<OperationSession> opSession_;
 #ifdef OEM_AMD
+    std::unique_ptr<sdbusplus::bus::match_t> biosGetTaskUpdatedMatch_;
+
+    void handleBiosGetTaskSignal(sdbusplus::message::message& msg,
+                                 uint32_t operationID,
+                                 std::shared_ptr<std::string> payloadBuffer);
     // Current operation ID being replayed
     uint32_t currentReplayOperationId_ = 0;
     // Current operation timestamp being replayed (used as key for completion)
@@ -341,8 +375,12 @@ class Device : public EntryIfaces, public std::enable_shared_from_this<Device>
     bool isReplayInProgress_ = false;
     // Manager reference for shared operation ID generation
     Manager* manager_ = nullptr;
+
+    CacheManagerObject* cacheManager_ = nullptr;
     // Signal match for TaskUpdated to track operation completion
     std::unique_ptr<sdbusplus::bus::match_t> taskUpdatedMatch_;
+    // Defer APCB TaskUpdated until after StartRedfishOperation returns to bmcweb
+    std::unique_ptr<sdeventplus::source::Defer> deferredApcbTaskSignal_;
 #endif
     bool shuttingDown_;
 };

--- a/rde/manager.cpp
+++ b/rde/manager.cpp
@@ -8,6 +8,8 @@
 #include <sdbusplus/message.hpp>
 #include <xyz/openbmc_project/PLDM/Event/server.hpp>
 
+#include <algorithm>
+#include <fstream>
 #include <future>
 #include <iomanip>
 #include <iostream>
@@ -17,6 +19,32 @@ PHOSPHOR_LOG2_USING;
 
 namespace pldm::rde
 {
+
+#ifdef OEM_AMD
+static void persistOperationId(uint32_t operationID)
+{
+    uint32_t current = 0;
+    std::ifstream inFile(operationIdFile);
+    if (inFile.is_open())
+    {
+        inFile >> current;
+    }
+
+    const uint32_t toWrite = std::max(current, operationID);
+    std::ofstream outFile(operationIdFile);
+    if (!outFile.is_open())
+    {
+        error("RDE: Failed to persist operation ID to {FILE}", "FILE",
+              operationIdFile);
+        return;
+    }
+
+    outFile << toWrite;
+    debug("RDE: Persisted operation ID {OID} to {FILE}", "OID", toWrite, "FILE",
+          operationIdFile);
+}
+#endif
+
 Manager::Manager(sdbusplus::bus::bus& bus, sdeventplus::Event& event,
                  pldm::InstanceIdDb* instanceIdDb,
                  pldm::requester::Handler<pldm::requester::Request>* handler) :
@@ -135,6 +163,7 @@ void Manager::createDeviceDbusObject(
 
 #ifdef OEM_AMD
     devicePtr->setManager(this);
+    devicePtr->setCacheManager(cacheManagerObj_.get());
 #endif
 
     DeviceContext context;
@@ -187,6 +216,7 @@ void Manager::registerOperationTask(uint32_t operationID,
                                     std::shared_ptr<OperationTaskIface> task)
 {
     taskMap_[operationID] = task;
+    persistOperationId(operationID);
     info("RDE: Registered OperationTask with operationID={OID}", "OID",
          operationID);
 }

--- a/rde/manager.hpp
+++ b/rde/manager.hpp
@@ -372,6 +372,9 @@ class Manager :
     pldm::requester::Handler<pldm::requester::Request>* handler_ = nullptr;
     sdbusplus::bus::bus& bus_;
     sdeventplus::Event& event_;
+#ifdef OEM_AMD
+    std::unique_ptr<CacheManagerObject> cacheManagerObj_;
+#endif
     std::unordered_map<eid, DeviceContext> eidMap_;
     std::unique_ptr<sdbusplus::bus::match_t> signalMatch_;
     std::unordered_map<eid, std::unique_ptr<sdbusplus::bus::match_t>>
@@ -381,9 +384,6 @@ class Manager :
                        std::shared_ptr<OperationTaskIface>>
         taskMap_;
     std::unique_ptr<sdbusplus::server::manager_t> objManager_;
-#ifdef OEM_AMD
-    std::unique_ptr<CacheManagerObject> cacheManagerObj_;
-#endif
 };
 
 } // namespace pldm::rde

--- a/rde/operation_session.cpp
+++ b/rde/operation_session.cpp
@@ -397,14 +397,19 @@ void OperationSession::doOperationInit()
     {
         error("Failed to send request OperationInit EID '{EID}', RC '{RC}'",
               "EID", eid_, "RC", rc);
-        updateState(OpState::OperationFailed);
-        dev->getInstanceIdDb().free(eid_, instanceId);
 #ifdef OEM_AMD
+        if (dev->getAPCBTokenCache(oipInfo))
+        {
+            dev->getInstanceIdDb().free(eid_, instanceId);
+            return;
+        }
         if (!dev->isReplayOperation(oipInfo) && dev->canCacheOperation(oipInfo))
         {
             dev->cacheOperation(oipInfo, "failed (init request)");
         }
 #endif
+        updateState(OpState::OperationFailed);
+        dev->getInstanceIdDb().free(eid_, instanceId);
         throw std::runtime_error("Failed to send request OperationInit");
     }
 
@@ -436,6 +441,10 @@ void OperationSession::handleOperationInitResp(const pldm_msg* respMsg,
         error("Null PLDM response received from endpoint ID {EID}", "EID",
               eid_);
 #ifdef OEM_AMD
+        if (dev->getAPCBTokenCache(oipInfo))
+        {
+            return;
+        }
         if (!dev->isReplayOperation(oipInfo) && dev->canCacheOperation(oipInfo))
         {
             dev->cacheOperation(oipInfo, "failed (NULL PLDM response)");

--- a/rde/operation_task.cpp
+++ b/rde/operation_task.cpp
@@ -46,6 +46,7 @@ int emitTaskUpdatedSignal(sdbusplus::bus_t& bus, const std::string& path,
         std::map<std::string, std::variant<std::string, uint16_t>> changed;
         changed.emplace("payload", payload);
         changed.emplace("return_code", returnCode);
+        changed.emplace("CompletionCode", returnCode);
 
         msg.append(changed);
         msg.signal_send();


### PR DESCRIPTION
Cache the APCB token data when the host boots up.
This will allow users to get the APCB Token data
when host is not available.