### PR TITLE
pldm: Generate signal for events with no data transfer handle

### DIFF
--- a/platform-mc/event_manager.cpp
+++ b/platform-mc/event_manager.cpp
@@ -184,6 +184,7 @@ int EventManager::handlePlatformEvent(
             terminus->pollEvent = true;
             terminus->pollEventId = poll_event.event_id;
             terminus->pollDataTransferHandle = poll_event.data_transfer_handle;
+            terminus->pollEventClass = eventClass;
         }
 
         return PLDM_SUCCESS;
@@ -709,6 +710,27 @@ exec::task<int> EventManager::pollForPlatformEventTask(
     std::vector<uint32_t> dataTransferHandles{}, eventDataSizes{};
     uint32_t currentDataTransferHandle = pollDataTransferHandle;
     std::deque<uint8_t> debugIds = {0, 1, 2, 3, 23, 24, 25, 33, 36, 37, 38, 40};
+
+    if (!pollDataTransferHandle)
+    {
+       auto it = termini.find(tid);
+       if (it != termini.end())
+       {
+           auto& terminus = it->second;
+           handlePollEventData(tid, formatVersion,
+                               terminus->pollEventClass, terminus->pollEventId,
+                               dataTransferHandles, eventDataSizes,
+                               completeEventMessage);
+       }
+       else
+       {
+           lg2::error("Unable to notify poll event: no terminus found for TID={TID}",
+                      "TID", tid);
+       }
+
+       co_return PLDM_SUCCESS;
+    }
+
 #endif
 
     // Reset and mark terminus as available

--- a/platform-mc/terminus.hpp
+++ b/platform-mc/terminus.hpp
@@ -264,6 +264,11 @@ class Terminus
      */
     uint32_t pollDataTransferHandle;
 
+    /** @brief The Event Class from the notification payload, used for
+     *         OEM AMD-specific parsing or routing of the polled event data.
+     */
+    uint8_t pollEventClass;
+
     /** @brief Get Sensor Auxiliary Names by sensorID
      *
      *  @param[in] id - sensor ID


### PR DESCRIPTION
platform-mc: Generate signal for events with no data transfer handle

Current pldmd implementation does not generate a D-Bus signal when it
receives a PollForPlatformEvent asynchronous message with a NULL data
transfer handle.

This change fixes that behavior by generating a
PldmMessagePollEvent signal with the event ID and a data length of zero
when no event data transfer is required.

For example, event ID 0x4D01 may be delivered with a NULL data transfer
handle. Prior to this change, no signal was generated for such events.
With this change, a PldmMessagePollEvent signal is emitted, allowing
applications that depend on these notifications to react appropriately.
