### PR TITLE
effecter: Do not apply unit modifier in PDR for numeric effecter read

### DIFF
--- a/platform-mc/effecters/numeric/effecter.cpp
+++ b/platform-mc/effecters/numeric/effecter.cpp
@@ -305,9 +305,7 @@ void NumericEffecter::updateValue(pldm_effecter_oper_state effecterOperState,
         }
         try
         {
-            intf->handleValueChange(*this, effecterOperState,
-                                    rawToBase(pendingValue),
-                                    rawToBase(presentValue), sizeEnum);
+            intf->handleValueChange(*this, effecterOperState, pendingValue, presentValue, sizeEnum);
         }
         catch (const std::exception& e)
         {


### PR DESCRIPTION
While reading values of a numeric effecter, do not apply
unit modifier from its PDR when values are stored.
PresentValue and PendingValue are not stored as engineering
value but are stored as PLDM Raw bytes.
