### PR TITLE
PldmMessagePollEvent: Emit correct event Id

### DIFF
--- a/platform-mc/event_manager.cpp
+++ b/platform-mc/event_manager.cpp
@@ -816,7 +816,7 @@ exec::task<int> EventManager::pollForPlatformEventTask(
                                         polledEventId, eventMessage);
 #ifdef OEM_AMD
                 handlePollEventData(polledEventTid, formatVersion,
-                                    polledEventClass, eventId,
+                                    polledEventClass, polledEventId,
                                     dataTransferHandles, eventDataSizes,
                                     eventMessage);
 #endif


### PR DESCRIPTION
When pldmd emits a D-Bus signal for PldmMessagePollEvent, it emits eventId along with other parameters.
Fix the incorrect eventId that gets emmited.

For example, emit UINT16 19457: instead of UINT16 0: