### PR TITLE
pldmd: Changes for 2X1P

### DIFF
--- a/common/types.hpp
+++ b/common/types.hpp
@@ -31,20 +31,25 @@ using MctpMedium = std::string;
  *         uint32_t is used as defined in MCTP Endpoint D-Bus Interface
  */
 using NetworkId = uint32_t;
+using NetworkInterface = std::string;
+using LocalEid = uint8_t;
 
 /** @brief Type definition of MCTP name in string
  */
 using MctpInfoName = std::optional<std::string>;
 
 /** @brief Type definition of MCTP interface information between two endpoints.
- *         eid : Endpoint EID in byte. Defined to match with MCTP D-Bus
- *               interface
- *         UUID : Endpoint UUID which is used to different the endpoints
- *         MctpMedium: Endpoint MCTP Medium info (Resersed)
- *         NetworkId: MCTP network index
- *         name: Alias name of the endpoint, e.g. BMC, NIC, etc.
+ *
+ *         eid              : Endpoint EID (byte). Matches MCTP D-Bus endpoint EID.
+ *         UUID             : Endpoint UUID used to uniquely identify endpoints.
+ *         MctpMedium       : Endpoint MCTP medium information (reserved/transport-specific).
+ *         NetworkId        : MCTP network index identifying the MCTP network.
+ *         MctpInfoName     : Alias name of the endpoint (e.g. BMC, NIC, etc.).
+ *         NetworkInterface : Underlying transport interface used for MCTP communication
+ *                            (e.g. mctpi3c4, mctppcie0).
+ *         LocalEid         : Host-assigned identifier associated with the interface.
  */
-using MctpInfo = std::tuple<eid, UUID, MctpMedium, NetworkId, MctpInfoName>;
+using MctpInfo = std::tuple<eid, UUID, MctpMedium, NetworkId, MctpInfoName, NetworkInterface, LocalEid>;
 
 /** @brief Type definition of MCTP endpoint D-Bus properties in
  *         xyz.openbmc_project.MCTP.Endpoint D-Bus interface.
@@ -54,7 +59,7 @@ using MctpInfo = std::tuple<eid, UUID, MctpMedium, NetworkId, MctpInfoName>;
  *               interface
  *         MCTPMsgTypes: MCTP message types
  */
-using MctpEndpointProps = std::tuple<NetworkId, eid, MCTPMsgTypes>;
+using MctpEndpointProps = std::tuple<NetworkId, eid, MCTPMsgTypes, NetworkInterface, LocalEid>;
 
 /** @brief Type defined for list of MCTP interface information
  */

--- a/configurations/pdr/com.amd.Hardware.Chassis/pdr_config.json
+++ b/configurations/pdr/com.amd.Hardware.Chassis/pdr_config.json
@@ -1,7 +1,13 @@
 {
   "uuids": {
-    "28318908-bc42-4463-a8f8-f0cc7b43c5e6": 0,
-    "8bc76e13-94c1-4e52-992b-d4d845e3572a": 1
+    "28318908-bc42-4463-a8f8-f0cc7b43c5e6": {
+      "mctpi3c4": 0,
+      "mctpi3c5": 1
+    },
+    "8bc76e13-94c1-4e52-992b-d4d845e3572a": {
+      "mctpi3c4": 0,
+      "mctpi3c5": 1
+    }
   },
 
   "excludeNumericEffecterPDRs": [

--- a/fw-update/manager.hpp
+++ b/fw-update/manager.hpp
@@ -56,7 +56,7 @@ class Manager : public pldm::MctpDiscoveryHandlerIntf
         std::vector<mctp_eid_t> eids;
         for (const auto& mctpInfo : mctpInfos)
         {
-            eids.emplace_back(std::get<mctp_eid_t>(mctpInfo));
+            eids.emplace_back(std::get<0>(mctpInfo));
         }
 
         inventoryMgr.discoverFDs(eids);

--- a/oem/amd/platform-mc/platform_manager.cpp
+++ b/oem/amd/platform-mc/platform_manager.cpp
@@ -324,7 +324,8 @@ std::optional<std::vector<uint8_t>> decode_compact_numeric_sensor_pdr(
 
 /* Setting default values when getPDRRepositoryInfo fails or does not support */
 exec::task<int> PlatformManager::get_pdr_from_json(
-    std::shared_ptr<Terminus> terminus, std::string targetUuid)
+    std::shared_ptr<Terminus> terminus, std::string targetUuid,
+    std::string networkInterface)
 {
     pldm_tid_t tid = terminus->getTid();
 
@@ -345,15 +346,24 @@ exec::task<int> PlatformManager::get_pdr_from_json(
             throw std::runtime_error("Could not open UUID mapping file");
         }
 
-        // 2. Parse directly into a map
-        auto j = nlohmann::json::parse(uuidFile);
-        auto uuid_map = j["uuids"].get<std::unordered_map<std::string, int>>();
+        using InterfaceMap = std::unordered_map<std::string, int>;
+        using UuidMap = std::unordered_map<std::string, InterfaceMap>;
 
-        // Early exit if the UUID is not in the map
-        auto it = uuid_map.find(targetUuid);
-        if (it == uuid_map.end())
+        // Parse JSON
+        auto j = nlohmann::json::parse(uuidFile);
+        auto uuidMap = j["uuids"].get<UuidMap>();
+
+        // Find UUID
+        auto uuidIt = uuidMap.find(targetUuid);
+        if (uuidIt == uuidMap.end())
         {
-            // UUID not found in the mapping
+            co_return PLDM_ERROR_INVALID_DATA;
+        }
+
+        // Find interface
+        auto ifaceIt = uuidIt->second.find(networkInterface);
+        if (ifaceIt == uuidIt->second.end())
+        {
             co_return PLDM_ERROR_INVALID_DATA;
         }
 
@@ -378,7 +388,7 @@ exec::task<int> PlatformManager::get_pdr_from_json(
         }
 #endif
 
-        int processorIndex = it->second;
+        int processorIndex = ifaceIt->second;
         std::string procName = "Processor" + std::to_string(processorIndex);
         std::string procPdrDir = pdrDir + "/" + procName;
         lg2::info("Loading PDRs for TID {TID} from {PATH}", "TID", tid, "PATH", procPdrDir);

--- a/platform-mc/platform_manager.cpp
+++ b/platform-mc/platform_manager.cpp
@@ -77,7 +77,8 @@ exec::task<int> PlatformManager::initTerminus()
             auto mctpInfo = terminusManager.getMctpInfoForTid(tid);
             if (mctpInfo.has_value()) {
                std::string uuid = std::get<1>(*mctpInfo);
-               auto rc = co_await get_pdr_from_json(terminus, uuid);
+               std::string networkInterface = std::get<2>(*mctpInfo);
+               auto rc = co_await get_pdr_from_json(terminus, uuid, networkInterface);
                if (rc)
                {
                    lg2::error(
@@ -140,7 +141,7 @@ exec::task<int> PlatformManager::initTerminus()
             if (info)
             {
                 pldm::utils::emitRDEDeviceDetectedSignal(
-                    tid, info->first, info->second, redfishResources);
+                    tid, std::get<0>(*info), std::get<1>(*info), redfishResources);
             }
             else
             {
@@ -541,6 +542,7 @@ exec::task<int> PlatformManager::setEventReceiver(
     pldm_tid_t tid, pldm_event_message_global_enable eventMessageGlobalEnable,
     pldm_transport_protocol_type protocolType, uint16_t heartbeatTimer)
 {
+    uint8_t localEid = 0;
     size_t requestBytes = PLDM_SET_EVENT_RECEIVER_REQ_BYTES;
     /**
      * Ignore heartbeatTimer bytes when eventMessageGlobalEnable is not
@@ -553,9 +555,21 @@ exec::task<int> PlatformManager::setEventReceiver(
     }
     Request request(sizeof(pldm_msg_hdr) + requestBytes);
     auto requestMsg = new (request.data()) pldm_msg;
+
+    auto info = terminusManager.getMctpInfoForTid(tid);
+    if (info)
+    {
+        localEid = std::get<3>(*info);
+    }
+    else
+    {
+        lg2::error("Failed to find Mctp Info for terminus with TID: {TID}", "TID", tid);
+    }
+    lg2::info("Set event receiver: LocalEid {LID} for tid: {TID}", "LID", localEid, "TID", tid);
+
     auto rc = encode_set_event_receiver_req(
         0, eventMessageGlobalEnable, protocolType,
-        terminusManager.getLocalEid(), heartbeatTimer, requestMsg);
+        localEid, heartbeatTimer, requestMsg);
     if (rc)
     {
         lg2::error(

--- a/platform-mc/platform_manager.hpp
+++ b/platform-mc/platform_manager.hpp
@@ -57,7 +57,9 @@ class PlatformManager
     exec::task<int> getPDRs(std::shared_ptr<Terminus> terminus);
 
 #ifdef OEM_AMD
-    exec::task<int> get_pdr_from_json(std::shared_ptr<Terminus> terminus, std::string targetUuid);
+    exec::task<int> get_pdr_from_json(
+        std::shared_ptr<Terminus> terminus, std::string targetUuid,
+        std::string networkInterface);
 #endif
 
     /** @brief Fetch PDR from terminus

--- a/platform-mc/terminus_manager.cpp
+++ b/platform-mc/terminus_manager.cpp
@@ -780,8 +780,8 @@ std::optional<mctp_eid_t> TerminusManager::getActiveEidByName(
     return std::nullopt;
 }
 
-std::optional<std::pair<eid, UUID>> TerminusManager::getMctpInfoForTid(
-    pldm_tid_t tid)
+std::optional<std::tuple<eid, UUID, NetworkInterface, LocalEid>>
+TerminusManager::getMctpInfoForTid(pldm_tid_t tid)
 {
     auto it = mctpInfoTable.find(tid);
     if (it == mctpInfoTable.end())
@@ -790,33 +790,14 @@ std::optional<std::pair<eid, UUID>> TerminusManager::getMctpInfoForTid(
     }
 
     const auto& mctpInfo = it->second;
-    return std::make_pair(std::get<0>(mctpInfo), std::get<1>(mctpInfo));
+
+    return std::make_tuple(
+        std::get<0>(mctpInfo),  // eid
+        std::get<1>(mctpInfo),  // uuid
+        std::get<5>(mctpInfo),  // interface
+        std::get<6>(mctpInfo)   // hostid
+    );
 }
 
-std::optional<uint8_t> TerminusManager::getBmcMctpEid()
-{
-    const std::string fileName = "/var/run/bmceid0";
-
-    try
-    {
-        std::ifstream toDevice;
-
-        toDevice.exceptions(std::ios::failbit | std::ios::badbit);
-        toDevice.open(fileName);
-
-        uint8_t bmcMctpEid = 0;
-        toDevice.read(reinterpret_cast<char*>(&bmcMctpEid), sizeof(bmcMctpEid));
-
-        return bmcMctpEid;
-    }
-
-    catch (const std::ios_base::failure& iose)
-    {
-        std::cerr << "In file I/O error: " << iose.what() << fileName
-                  << std::endl;
-    }
-
-    return std::nullopt;
-}
 } // namespace platform_mc
 } // namespace pldm

--- a/platform-mc/terminus_manager.hpp
+++ b/platform-mc/terminus_manager.hpp
@@ -146,20 +146,6 @@ class TerminusManager
      */
     bool unmapTid(const pldm_tid_t& tid);
 
-    /** @brief getter of local EID
-     *
-     *  @return uint8_t - local EID
-     */
-    mctp_eid_t getLocalEid()
-    {
-        auto hostEid = getBmcMctpEid();
-
-        if (hostEid.has_value())
-            return *hostEid;
-
-        return localEid;
-    }
-
     /** @brief Helper function to invoke registered handlers for
      *  updating the availability status of the MCTP endpoint
      *
@@ -196,18 +182,20 @@ class TerminusManager
      * @return std::optional<std::pair<eid, UUID>> Returns a pair of EID and
      * UUID if the TID is found, or std::nullopt if not found.
      */
-    std::optional<std::pair<eid, UUID>> getMctpInfoForTid(pldm_tid_t tid);
+    std::optional<std::tuple<eid, UUID, NetworkInterface, LocalEid>> getMctpInfoForTid(
+        pldm_tid_t tid);
 
     /**
      * @brief Get the BMC Host EID stored in a file
      *
-     * This function looks up the a file and if the file exists and
+     * This function looks up a file and, if the file exists and
      * can be read, reads the MCTP EID stored in that file.
      *
-     * @return std::optional<std::<uint8_t> Returns a BMC MCTP EID
-     * stored in the file and in case of any errors, return NULL value.
+     * @param[in] hostNumber The identifier of the specific host.
+     * @return std::optional<uint8_t> Returns the BMC MCTP EID stored
+     *         in the file, or std::nullopt in case of any errors.
      */
-    std::optional<uint8_t> getBmcMctpEid();
+    std::optional<uint8_t> getBmcMctpEid(const int hostNumber);
 
   private:
     /** @brief Find the terminus object pointer in termini list.

--- a/requester/mctp_endpoint_discovery.cpp
+++ b/requester/mctp_endpoint_discovery.cpp
@@ -85,8 +85,10 @@ void MctpDiscovery::getMctpInfos(std::map<MctpInfo, Availability>& mctpInfoMap)
                 types.end())
             {
                 auto mctpInfo =
-                    MctpInfo(std::get<eid>(epProps), uuid, "",
-                             std::get<NetworkId>(epProps), std::nullopt);
+                    MctpInfo(std::get<1>(epProps), uuid, "",
+                             std::get<0>(epProps), std::nullopt,
+                             std::get<3>(epProps),
+                             std::get<4>(epProps));
                 searchConfigurationFor(pldm::utils::DBusHandler(), mctpInfo);
                 mctpInfoMap[std::move(mctpInfo)] = availability;
             }
@@ -103,13 +105,17 @@ MctpEndpointProps MctpDiscovery::getMctpEndpointProps(
             service.c_str(), path.c_str(), MCTPInterface);
 
         if (properties.contains("NetworkId") && properties.contains("EID") &&
+            properties.contains("NetworkInterface") &&
+            properties.contains("LocalEid") &&
             properties.contains("SupportedMessageTypes"))
         {
             auto networkId = std::get<NetworkId>(properties.at("NetworkId"));
             auto eid = std::get<mctp_eid_t>(properties.at("EID"));
             auto types = std::get<std::vector<uint8_t>>(
                 properties.at("SupportedMessageTypes"));
-            return MctpEndpointProps(networkId, eid, types);
+            auto networkInterface = std::get<NetworkInterface>(properties.at("NetworkInterface"));
+            auto localEid = std::get<LocalEid>(properties.at("LocalEid"));
+            return MctpEndpointProps(networkId, eid, types, networkInterface, localEid);
         }
     }
     catch (const sdbusplus::exception_t& e)
@@ -117,10 +123,10 @@ MctpEndpointProps MctpDiscovery::getMctpEndpointProps(
         error(
             "Error reading MCTP Endpoint property at path '{PATH}' and service '{SERVICE}', error - {ERROR}",
             "SERVICE", service, "PATH", path, "ERROR", e);
-        return MctpEndpointProps(0, MCTP_ADDR_ANY, {});
+        return MctpEndpointProps(0, MCTP_ADDR_ANY, {}, "", 0);
     }
 
-    return MctpEndpointProps(0, MCTP_ADDR_ANY, {});
+    return MctpEndpointProps(0, MCTP_ADDR_ANY, {}, "", 0);
 }
 
 UUID MctpDiscovery::getEndpointUUIDProp(const std::string& service,
@@ -202,8 +208,8 @@ void MctpDiscovery::getAddedMctpInfos(sdbusplus::message_t& msg,
     }
     catch (const sdbusplus::exception_t& e)
     {
-        error("Error getting Endpoint UUID D-Bus interface, error - {ERROR}",
-              "ERROR", e);
+        error("Error getting Endpoint UUID D-Bus interface for {OBJP}, error - {ERROR}",
+              "OBJP", objPath.str, "ERROR", e);
     }
 
     for (const auto& [intfName, properties] : interfaces)
@@ -212,6 +218,8 @@ void MctpDiscovery::getAddedMctpInfos(sdbusplus::message_t& msg,
         {
             if (properties.contains("NetworkId") &&
                 properties.contains("EID") &&
+                properties.contains("NetworkInterface") &&
+                properties.contains("LocalEid") &&
                 properties.contains("SupportedMessageTypes"))
             {
                 auto networkId =
@@ -219,6 +227,10 @@ void MctpDiscovery::getAddedMctpInfos(sdbusplus::message_t& msg,
                 auto eid = std::get<mctp_eid_t>(properties.at("EID"));
                 auto types = std::get<std::vector<uint8_t>>(
                     properties.at("SupportedMessageTypes"));
+                auto networkInterface = std::get<NetworkInterface>(
+                    properties.at("NetworkInterface"));
+                auto localEid = std::get<LocalEid>(
+                    properties.at("LocalEid"));
 
                 if (!availability)
                 {
@@ -232,10 +244,12 @@ void MctpDiscovery::getAddedMctpInfos(sdbusplus::message_t& msg,
                     types.end())
                 {
                     info(
-                        "Adding Endpoint networkId '{NETWORK}' and EID '{EID}' UUID '{UUID}'",
-                        "NETWORK", networkId, "EID", eid, "UUID", uuid);
+                        "Adding Endpoint networkId '{NETWORK}' and EID '{EID}' "
+                        "UUID '{UUID}' Interface '{NINTF}' LocalEid '{LID}'",
+                        "NETWORK", networkId, "EID", eid,
+                        "UUID", uuid, "NINTF", networkInterface, "LID", localEid);
                     auto mctpInfo =
-                        MctpInfo(eid, uuid, "", networkId, std::nullopt);
+                        MctpInfo(eid, uuid, "", networkId, std::nullopt, networkInterface, localEid);
                     searchConfigurationFor(pldm::utils::DBusHandler(),
                                            mctpInfo);
                     mctpInfos.emplace_back(std::move(mctpInfo));
@@ -322,8 +336,10 @@ void MctpDiscovery::propertiesChangedCb(sdbusplus::message_t& msg)
             }
             const UUID& uuid = getEndpointUUIDProp(service, objPath);
 
-            MctpInfo mctpInfo(std::get<eid>(epProps), uuid, "",
-                              std::get<NetworkId>(epProps), std::nullopt);
+            MctpInfo mctpInfo(std::get<1>(epProps), uuid, "",
+                              std::get<0>(epProps), std::nullopt,
+                              std::get<3>(epProps),
+                              std::get<4>(epProps));
             searchConfigurationFor(pldm::utils::DBusHandler(), mctpInfo);
             if (!std::ranges::contains(existingMctpInfos, mctpInfo))
             {
@@ -420,8 +436,8 @@ std::string MctpDiscovery::getNameFromProperties(
 std::string MctpDiscovery::constructMctpReactorObjectPath(
     const MctpInfo& mctpInfo)
 {
-    const auto networkId = std::get<NetworkId>(mctpInfo);
-    const auto eid = std::get<pldm::eid>(mctpInfo);
+    const auto networkId = std::get<3>(mctpInfo);
+    const auto eid = std::get<0>(mctpInfo);
     return std::string{MCTPPath} + "/networks/" + std::to_string(networkId) +
            "/endpoints/" + std::to_string(eid) + "/configured_by";
 }
@@ -498,10 +514,10 @@ void MctpDiscovery::removeConfigs(const MctpInfos& removedInfos)
 {
     for (const auto& mctpInfo : removedInfos)
     {
-        auto eidToRemove = std::get<eid>(mctpInfo);
+        auto eidToRemove = std::get<0>(mctpInfo);
         std::erase_if(configurations, [eidToRemove](const auto& config) {
             auto& [__, mctpInfo] = config;
-            auto eidValue = std::get<eid>(mctpInfo);
+            auto eidValue = std::get<0>(mctpInfo);
             return eidValue == eidToRemove;
         });
     }


### PR DESCRIPTION
Changes for 2X1P and Set Event Receiver code.

Use endpoint property LocalEid value as a
local BMC eid for an interface and use the eid for Set Event Receiver command instead of relying bmceid files under /var/run.

Rely on UUID and Network Interface name to identify processor id such as 0 and 1 since in 2x1P mode, both the SoC emit the same UUID.