### PR TITLE
pldm: Generate signal for events with null data transfer handle

### DIFF
--- a/platform-mc/event_manager.cpp
+++ b/platform-mc/event_manager.cpp
@@ -181,6 +181,21 @@ int EventManager::handlePlatformEvent(
                logPldmErrorEvent(tid, eventId, eventClass, eventData, eventDataSize);
 
             auto& terminus = it->second; // Reference for clarity
+
+#ifdef OEM_AMD
+            if (!poll_event.data_transfer_handle) {
+                // Wrap the single uint32_t values into std::vector containers
+                uint8_t formatVersion = poll_event.format_version;
+                std::vector<uint32_t> handle = { poll_event.data_transfer_handle };
+                std::vector<uint32_t> sizes = { 0 };
+                std::vector<uint8_t> eventMsg = {}; // Empty vector for the last argument
+
+                handlePollEventData(tid, formatVersion, eventClass, poll_event.event_id,
+                                    handle, sizes, eventMsg);
+
+                return PLDM_SUCCESS;
+            }
+#endif
             terminus->pollEvent = true;
             terminus->pollEventId = poll_event.event_id;
             terminus->pollDataTransferHandle = poll_event.data_transfer_handle;


### PR DESCRIPTION
Generate a signal right away when pldm event is recevied with a null data transfer handle instead of handling the event during the sensor loop which can add latency of upto five seconds.

There are certain BMC services that need to be started as soon as certain event is generated and can not wait for event to be handled during sensor loop.
