### PR TITLE
pldmtool: Use a non-listening transport for command access

### DIFF
--- a/common/transport.hpp
+++ b/common/transport.hpp
@@ -19,7 +19,7 @@ union TransportImpl
 class PldmTransport
 {
   public:
-    PldmTransport();
+    PldmTransport(bool listening = true);
     PldmTransport(const PldmTransport& other) = delete;
     PldmTransport(const PldmTransport&& other) = delete;
     PldmTransport& operator=(const PldmTransport& other) = delete;

--- a/pldmtool/pldm_cmd_helper.cpp
+++ b/pldmtool/pldm_cmd_helper.cpp
@@ -286,7 +286,7 @@ int CommandInterface::pldmSendRecv(std::vector<uint8_t>& requestMsg,
     }
 
     auto tid = mctp_eid;
-    PldmTransport pldmTransport{};
+    PldmTransport pldmTransport(false);
     uint8_t retry = 0;
     int rc = PLDM_ERROR;
 


### PR DESCRIPTION
pldmtool does not really need to create a listening (bind) transport to do a simple send/receive transaction. Hence refactor PldmTransport allowing a user to specify if the required transport is expected to be listening or non-listening and switch pldmtool to use a non-listening transport.

Change-Id: I390298397d71c0ea27234880b844898c7a100ca5